### PR TITLE
Removed reliance on 'provider' field within secrets

### DIFF
--- a/src/keydra/keydra.py
+++ b/src/keydra/keydra.py
@@ -39,7 +39,8 @@ class Keydra(object):
             LOGGER.error(e)
             return [self._fail(e)]
 
-        self._emit_spec_metrics(secrets)
+        if rotate != 'adhoc':
+            self._emit_spec_metrics(secrets)
 
         if not secrets:
             return [self._success(
@@ -74,13 +75,19 @@ class Keydra(object):
 
             resp.append(result)
 
-        self._emit_result_metrics(resp)
+        if rotate != 'adhoc':
+            self._emit_result_metrics(resp)
 
         return resp
 
     def _redact_secrets(self, result, spec):
         r_result = copy.deepcopy(result)
-        provider = r_result.get('value', {}).get('provider', '')
+        provider = spec['provider']
+
+        LOGGER.debug(
+            'Redacting the value of {}::{}'.format(
+                spec['provider'],
+                spec['key']))
 
         try:
             km_provider = loader.load_provider_client(provider)

--- a/src/keydra/loader.py
+++ b/src/keydra/loader.py
@@ -140,7 +140,11 @@ def load_client(provider):
 
 def build_client(secret_provider, key_name):
     km_provider = load_provider_client(secret_provider)
-    credentials = fetch_provider_creds(secret_provider, key_name)
+    credentials = None
+    if km_provider.has_creds():
+        credentials = fetch_provider_creds(secret_provider, key_name)
+    else:
+        LOGGER.debug('Don\'t need to fetch creds for ' + secret_provider)
 
     return km_provider(
         session=SESSION,

--- a/src/keydra/providers/aws_secretsmanager.py
+++ b/src/keydra/providers/aws_secretsmanager.py
@@ -98,9 +98,8 @@ class SecretsManagerProvider(BaseProvider):
             )
 
         LOGGER.info(
-            'Successfully distributed {} to SecretsManager from {}'.format(
-                dest['key'],
-                secret['provider']
+            'Successfully distributed {} to SecretsManager'.format(
+                dest['key']
             )
         )
 
@@ -189,3 +188,7 @@ class SecretsManagerProvider(BaseProvider):
                     result['value'][key] = '***'
 
         return result
+
+    @classmethod
+    def has_creds(cls):
+        return False

--- a/src/keydra/providers/base.py
+++ b/src/keydra/providers/base.py
@@ -82,3 +82,7 @@ class BaseProvider(ABC):
     @classmethod
     def redact_result(self, result):
         return result
+
+    @classmethod
+    def has_creds(cls):
+        return True

--- a/tests/test_keydra.py
+++ b/tests/test_keydra.py
@@ -160,14 +160,14 @@ class TestKeydra(unittest.TestCase):
         bbc_distribute.return_value = "distributed"
 
         result = self._kdra.rotate_and_distribute(
-            run_for_secrets=CONFIG, rotate='adhoc')
+            run_for_secrets=CONFIG, rotate='nightly')
 
         self._kdra._cw.put_metric_data.assert_called()
 
         self.assertEqual(result[0]['rotate_secret']['status'], 'success')
         self.assertEqual(result[0]['distribute_secret']['status'], 'success')
         self._cfg.load_secrets.assert_called_once_with(
-            secrets=CONFIG, rotate='adhoc')
+            secrets=CONFIG, rotate='nightly')
 
     def test__distribute_secret_failure(self):
         result = self._kdra._distribute_secret({


### PR DESCRIPTION
```
Name                                     Stmts   Miss Branch BrPart  Cover
--------------------------------------------------------------------------
keydra/__init__.py                           0      0      0      0   100%
keydra/clients/__init__.py                   0      0      0      0   100%
keydra/clients/aws/__init__.py               0      0      0      0   100%
keydra/clients/aws/appsync.py               35     19      2      0    43%
keydra/clients/aws/cloudwatch.py            42      5     10      1    88%
keydra/clients/aws/secretsmanager.py        45     23      6      0    47%
keydra/clients/bitbucket.py                 97     71      8      0    25%
keydra/clients/cloudflare.py                44     29      0      0    34%
keydra/clients/contentful.py                23      0      2      0   100%
keydra/clients/qualys.py                    37      3      6      1    91%
keydra/clients/salesforce.py                25      0      8      0   100%
keydra/clients/splunk.py                    46      7     10      2    84%
keydra/config.py                           106      9     68      6    91%
keydra/exceptions.py                         8      0      0      0   100%
keydra/keydra.py                           143     23     52     13    81%
keydra/loader.py                            68      5     20      5    89%
keydra/logging.py                           14      0      0      0   100%
keydra/providers/__init__.py                 0      0      0      0   100%
keydra/providers/aws_appsync.py             71     17     14      5    72%
keydra/providers/aws_iam.py                119      3     46      6    95%
keydra/providers/aws_secretsmanager.py      93      3     18      1    96%
keydra/providers/base.py                    46      2     10      1    95%
keydra/providers/bitbucket.py              156      4     62      6    95%
keydra/providers/cloudflare.py              51      0     20      1    99%
keydra/providers/contentful.py              35      0      4      0   100%
keydra/providers/qualys.py                  52      3     14      2    92%
keydra/providers/salesforce.py              65      3     20      4    92%
keydra/providers/splunk.py                  80      7     24      2    91%
--------------------------------------------------------------------------
TOTAL                                     1501    236    424     56    84%
----------------------------------------------------------------------
Ran 193 tests in 5.593s

OK
```

Adhoc execution:
```
{
    "asctime": "2021-05-28 04:38:51,408",
    "levelname": "INFO",
    "lambda": "keydra",
    "message": "Finished execution of Keydra for the ADHOC run. Secrets: sf_canary",
    "data": [
        {
            "secret_id": "salesforce::keydra-canary",
            "key": "keydra-canary",
            "provider": "salesforce",
            "rotate_secret": {
                "status": "success",
                "action": "rotate_secret",
                "value": {
                    "SF_URL": "https://test.salesforce.com",
                    "SF_USERNAME": "keydra-canary@athena.com.au.dev3",
                    "SF_PASSWORD": "***",
                    "SF_TOKEN": "***",
                    "SF_DOMAIN": "test",
                    "SF_REST_URI": "https://athenafinancial--dev3.cs57.my.salesforce.com/services",
                    "SF_AUTH_URL": "https://athenafinancial--dev3.cs57.my.salesforce.com/services/Soap/c/40.0"
                }
            },
            "distribute_secret": {
                "status": "success",
                "value": [
                    {
                        "status": "success",
                        "value": {
                            "envs": [
                                "dev"
                            ],
                            "key": "keydra/salesforce/keydra-canary",
                            "provider": "secretsmanager",
                            "source": "secret"
                        }
                    }
                ]
            }
        }
    ]
}
```