### PR TITLE
[Linter] Increased line length to 100 chars

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,4 @@ cover-package=keydra
 
 [flake8]
 exclude = .git,.aws-sam,__pycache__,build,dist
+max-line-length = 100


### PR DESCRIPTION
We're tripping over this way too often, and have no good reason to enforce ultra short lines.