### PR TITLE
Prevented AWS providers from reading secrets from SM

### DIFF
--- a/src/keydra/providers/aws_appsync.py
+++ b/src/keydra/providers/aws_appsync.py
@@ -130,3 +130,7 @@ class Client(BaseProvider):
             result['value']['secret'] = '***'
 
         return result
+
+    @classmethod
+    def has_creds(cls):
+        return False

--- a/src/keydra/providers/aws_iam.py
+++ b/src/keydra/providers/aws_iam.py
@@ -289,3 +289,7 @@ class Client(BaseProvider):
                         .format(unknown_vals))
 
             return True, 'All good!'
+
+    @classmethod
+    def has_creds(cls):
+        return False


### PR DESCRIPTION
Keydra has direct access (IAM) to change credentials for AWS providers, and doesn't need to retrieve the original credentials from Secrets Manager. 

Since we started throwing errors when we fail to access secrets in #19, the providers have started to fail. 

```
Name                                     Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------------------------------
keydra/__init__.py                           0      0      0      0   100%
keydra/clients/__init__.py                   0      0      0      0   100%
keydra/clients/aws/__init__.py               0      0      0      0   100%
keydra/clients/aws/appsync.py               35     19      2      0    43%   24-27, 53-56, 82-89, 108-114, 180-185
keydra/clients/aws/cloudwatch.py            42      5     10      1    88%   11->12, 12, 19, 22, 98-99
keydra/clients/aws/secretsmanager.py        45     23      6      0    47%   40-52, 75-88, 134-139, 169-178, 201-207
keydra/clients/bitbucket.py                 97     71      8      0    25%   24-31, 34-41, 44-51, 54-58, 61-80, 94-96, 119-128, 154-167, 180-186, 200-202, 228-246, 268-272, 302-313, 346-357, 375-379, 405-416, 446-457, 479-481
keydra/clients/cloudflare.py                44     29      0      0    34%   23-30, 33-40, 43-50, 53-57, 67-69, 81-83, 93-95, 105-107
keydra/clients/contentful.py                23      0      2      0   100%
keydra/clients/qualys.py                    37      3      6      1    91%   84->92, 92, 141-142
keydra/clients/salesforce.py                25      0      8      0   100%
keydra/clients/splunk.py                    46      7     10      2    84%   75->77, 77-78, 119->120, 120, 147-148, 153-154
keydra/config.py                           106      9     68      6    91%   40, 57->58, 58, 70->81, 71->72, 72, 105->106, 106, 120->121, 121-123, 181-187, 189->125
keydra/exceptions.py                         8      0      0      0   100%
keydra/keydra.py                           143     23     52     13    81%   38-40, 42->45, 45->46, 46, 72->76, 78->81, 97-100, 113->114, 114, 118-119, 130->131, 131, 142->143, 143, 145->138, 148->149, 149, 154->155, 155, 179->180, 180, 189-190, 258-259, 268->271, 271-272, 279->274, 332-333
keydra/loader.py                            69      5     20      5    89%   84->85, 85, 90->91, 91, 119->120, 120, 125->126, 126, 144->147, 147
keydra/logging.py                           14      0      0      0   100%
keydra/providers/__init__.py                 0      0      0      0   100%
keydra/providers/aws_appsync.py             71     17     14      5    72%   27->28, 28, 56->57, 57-64, 66->67, 67-79, 103-107, 119->120, 120, 129->132
keydra/providers/aws_iam.py                119      3     46      6    95%   28->29, 29, 162->163, 163, 229->240, 240->249, 263->266, 271->272, 272
keydra/providers/aws_secretsmanager.py      93      3     18      1    96%   158-159, 185->190, 194
keydra/providers/base.py                    46      2     10      1    95%   39->exit, 49, 53
keydra/providers/bitbucket.py              156      4     62      6    95%   37->36, 149->148, 214->213, 226->227, 227, 296, 414->415, 415, 419->420, 420
keydra/providers/cloudflare.py              51      0     20      1    99%   96->101
keydra/providers/contentful.py              35      0      4      0   100%
keydra/providers/qualys.py                  52      3     14      2    92%   94, 106->107, 107, 109->110, 110
keydra/providers/salesforce.py              65      3     20      4    92%   30->31, 31, 61->62, 62, 127->128, 128, 143->142
keydra/providers/splunk.py                  80      7     24      2    91%   104-124, 194->195, 195, 231, 246->251
------------------------------------------------------------------------------------
TOTAL                                     1502    236    424     56    84%
----------------------------------------------------------------------
Ran 194 tests in 5.911s

OK
```