### PR TITLE
Avoid clashing Splunk deployment tasks

### DIFF
--- a/src/keydra/clients/splunk.py
+++ b/src/keydra/clients/splunk.py
@@ -340,6 +340,9 @@ class SplunkClient(object):
 
         '''
         try:
+            # Allow any existing in progress tasks to complete first
+            self._wait_for_splunkcloud_task(id=self._get_last_splunkcloud_deploytask())
+
             self._service.delete(
                 '/services/dmc/config/inputs/__indexers/http/{}'.format(inputname),
                 output_mode='json'


### PR DESCRIPTION
Added a check/wait for Splunk Deployment tasks before attempting to rotate a token. At larger scale, tasks were attempting to be submitted while Keydra was still actioning another one - resulting in failed actions.

This minor change avoids this problem.