### PR TITLE
Update Tests

### DIFF
--- a/src/keydra/clients/splunk.py
+++ b/src/keydra/clients/splunk.py
@@ -382,7 +382,7 @@ class SplunkClient(object):
         :rtype: :class:`tuple`
 
         '''
-
+        self._wait_for_splunkcloud_task(id=self._get_last_splunkcloud_deploytask())
         try:
             createresp = self._service.post(
                 '/services/dmc/config/inputs/__indexers/http',
@@ -393,6 +393,7 @@ class SplunkClient(object):
 
         except HTTPError as error:
             if 'deployment task is still in progress' in str(error.body):
+                LOGGER.info('Could not deploy task, another task is already in progress. Retrying.')
                 raise TaskAlreadyInProgressException()
 
             raise Exception(

--- a/tests/test_client_splunk.py
+++ b/tests/test_client_splunk.py
@@ -423,7 +423,8 @@ class TestSplunkClient(unittest.TestCase):
             )
 
         sp_client._get_last_splunkcloud_deploytask = MagicMock()
-
+        sp_client._wait_for_splunkcloud_task = MagicMock()
+        
         sp_client._service.post.return_value['body'] = MagicMock()
         sp_client._service.post.return_value['body'].read.return_value = json.dumps(
             {


### PR DESCRIPTION
Updating the tests to resolve the "TypeError: the JSON object must be str, bytes or bytearray, not MagicMock" nosetests error in keydra/clients/splunk.py.