### PR TITLE
Add support for weekly rotations

### DIFF
--- a/docsrc/sample_template.yaml
+++ b/docsrc/sample_template.yaml
@@ -44,6 +44,15 @@ Resources:
             Input: '{"trigger": "nightly"}'
             Enabled: true
 
+        KeydraWeekly:
+          Type: Schedule
+          Properties:
+            Schedule: 'cron(0 14 ? * SUN *)'
+            Name: keydra-weekly
+            Description: Keydra weekly key rotation
+            Input: '{"trigger": "weekly"}'
+            Enabled: true
+
         KeydraMonthly:
           Type: Schedule
           Properties:

--- a/src/keydra/config.py
+++ b/src/keydra/config.py
@@ -20,7 +20,7 @@ ENV_TYPE_SPEC = {
 SECRETS_SPEC = ['key', 'provider']
 SECRET_ENV_SPEC = ['key', 'provider', 'source', 'envs']
 
-ALLOWED_ROTATION_SCHEDULES = ['nightly', 'monthly', 'adhoc', 'canaries']
+ALLOWED_ROTATION_SCHEDULES = ['nightly', 'weekly', 'monthly', 'adhoc', 'canaries']
 
 LOGGER = get_logger()
 

--- a/tests/test_client_splunk.py
+++ b/tests/test_client_splunk.py
@@ -424,7 +424,7 @@ class TestSplunkClient(unittest.TestCase):
 
         sp_client._get_last_splunkcloud_deploytask = MagicMock()
         sp_client._wait_for_splunkcloud_task = MagicMock()
-        
+
         sp_client._service.post.return_value['body'] = MagicMock()
         sp_client._service.post.return_value['body'].read.return_value = json.dumps(
             {


### PR DESCRIPTION
Adding support for weekly schedules. This is mainly controlled by how the lambda is invoked, but this change just updates the permitted schedule types so a weekly invocation will be allowed.

Also updated the sample template file, to show how you would define this schedule in CloudWatch.