### PR TITLE
Fix for Salesforce passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ nosetests.xml
 .aws-sam
 samconfig.toml
 template.yaml
+.idea

--- a/src/keydra/providers/salesforce.py
+++ b/src/keydra/providers/salesforce.py
@@ -46,7 +46,7 @@ class Client(BaseProvider):
         # https://trailblazer.salesforce.com/issues_view?id=a1p3A000000AT9rQAG
         passwd = self._smclient.generate_random_password(
             length=length,
-            IncludeSpace=True,
+            IncludeSpace=False,
             ExcludeCharacters='!"%&\'()*+,-./:;<=>?[\\]^_`{|}~$'
         )
 

--- a/tests/test_provider_salesforce.py
+++ b/tests/test_provider_salesforce.py
@@ -306,7 +306,7 @@ class TestProviderSalesforce(unittest.TestCase):
         cli._rotate_secret(spec=SF_CREDS)
 
         cli._smclient.generate_random_password.assert_called_once_with(
-            IncludeSpace=True,
+            IncludeSpace=False,
             length=32,
             ExcludeCharacters='!"%&\'()*+,-./:;<=>?[\\]^_`{|}~$'
         )


### PR DESCRIPTION
We are experiencing inconsistent behaviour from the Salesforce platform (Web, SOAP & OAuth) when dealing with passwords containing leading spaces.