### PR TITLE
bugfix/sfmc-provider

### DIFF
--- a/src/keydra/providers/salesforce_marketing_cloud.py
+++ b/src/keydra/providers/salesforce_marketing_cloud.py
@@ -24,7 +24,7 @@ class Client(BaseProvider):
         user_field: str = 'key'
         password_field: str = 'secret'
         subdomain_field: str = 'subdomain'
-        business_unit_field: int = 'business_unit'
+        businessUnit_field: int = 'businessUnit'
         mid_field: int = 'mid'
 
     def __init__(self, session=None, credentials: dict = None, region_name=None):
@@ -68,7 +68,7 @@ class Client(BaseProvider):
             password=self._orig_secret[opts.password_field],
             subdomain=self._orig_secret[opts.subdomain_field],
             mid=self._orig_secret[opts.mid_field],
-            business_unit=self._orig_secret[opts.business_unit_field]
+            businessUnit=self._orig_secret[opts.businessUnit_field]
         )
 
         # Generate new random password from SecretsManager
@@ -137,7 +137,7 @@ class Client(BaseProvider):
 
         if 'value' in result:
             for field in (
-                opts.password_field, opts.business_unit_field, opts.mid_field, opts.subdomain_field
+                opts.password_field, opts.businessUnit_field, opts.mid_field, opts.subdomain_field
             ):
                 if field in result['value']:
                     result['value'][field] = '***'

--- a/tests/test_provider_salesforce_marketing_cloud.py
+++ b/tests/test_provider_salesforce_marketing_cloud.py
@@ -16,14 +16,14 @@ SFMC_CREDS = {
     "secret": "test",
     "subdomain": "abc@_!xyz",
     "mid": 123456789,
-    "business_unit": 987654321,
+    "businessUnit": 987654321,
 }
 
 SFMC_CFG = {
     'user_field': 'SF_USERNAME',
     'password_field': 'SF_PASSWORD',
     'subdomain_field': 'SF_SUBDOMAIN',
-    'business_unit_field': 'SF_BUSINESUNIT',
+    'businessUnit_field': 'SF_BUSINESUNIT',
     'mid_field': 'SF_MID'
 }
 
@@ -39,7 +39,7 @@ SFMC_SPEC = {
             'key': 'keydra/salesforce/sfmc_test_api',
             'subdomain': 'abc@_!xyz',
             'mid': 123456789,
-            'business_unit': 987654321,
+            'businessUnit': 987654321,
         },
         {
             'provider': 'bitbucket',
@@ -93,7 +93,7 @@ class TestProviderSalesforce(unittest.TestCase):
         self.assertEqual(result['secret'], new_pass)
         self.assertEqual(result['subdomain'], SFMC_CREDS['subdomain'])
         self.assertEqual(result['mid'], SFMC_CREDS['mid'])
-        self.assertEqual(result['business_unit'], SFMC_CREDS['business_unit'])
+        self.assertEqual(result['businessUnit'], SFMC_CREDS['businessUnit'])
 
     @patch.object(SecretsManagerClient, 'generate_random_password')
     @patch.object(SalesforceMarketingCloudClient, 'change_passwd')
@@ -174,7 +174,7 @@ class TestProviderSalesforce(unittest.TestCase):
                 'secret': 'THIS_IS_SECRET',
                 'subdomain': 'this is also secret',
                 'mid': 'this is also secret',
-                'business_unit': 'this is also secret'
+                'businessUnit': 'this is also secret'
             }
         }
 
@@ -183,7 +183,7 @@ class TestProviderSalesforce(unittest.TestCase):
         self.assertNotEqual(r_result['value']['secret'], 'THIS_IS_SECRET')
         self.assertNotEqual(r_result['value']['subdomain'], 'this is also secret')
         self.assertNotEqual(r_result['value']['mid'], 'this is also secret')
-        self.assertNotEqual(r_result['value']['business_unit'], 'this is also secret')
+        self.assertNotEqual(r_result['value']['businessUnit'], 'this is also secret')
 
     def test__redact_result_overriden_fields(self):
         result = {


### PR DESCRIPTION
init() bugfix ref incorrect businessUnit value config being referenced in the provider to the client (Python TypeError catch). Client expects `businessUnit`, but provider expects `business_unit`. Now the provider should expect `businessUnit` and pass this into the Client.