### PR TITLE
type fix for SFMC provider function (userId --> username)

### DIFF
--- a/src/keydra/providers/salesforce_marketing_cloud.py
+++ b/src/keydra/providers/salesforce_marketing_cloud.py
@@ -82,7 +82,7 @@ class Client(BaseProvider):
         # Change Salesforce Marketing Cloud password
         try:
             client.change_passwd(
-                userid=self._orig_secret[opts.user_field],
+                username=self._orig_secret[opts.user_field],
                 newpassword=new_passwd
             )
 

--- a/tests/test_provider_salesforce_marketing_cloud.py
+++ b/tests/test_provider_salesforce_marketing_cloud.py
@@ -84,7 +84,7 @@ class TestProviderSalesforce(unittest.TestCase):
 
         # Assert
         sfmc_cp.assert_called_once_with(
-            userid=SFMC_CREDS['key'],
+            username=SFMC_CREDS['key'],
             newpassword=new_pass
         )
 
@@ -121,7 +121,7 @@ class TestProviderSalesforce(unittest.TestCase):
 
         # Assert
         sfmc_cp.assert_called_once_with(
-            userid=orig_secret['SF_USERNAME'],
+            username=orig_secret['SF_USERNAME'],
             newpassword=new_pass
         )
 


### PR DESCRIPTION
Another small bugfix. This time it's a typeError on change_password Client function. It was expecting username, but provider was passing in userId.

Updated tests respectively.