### PR TITLE
Feature/aws ssm

### DIFF
--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -91,16 +91,41 @@ Uses client `AWS Kinesis Firehose`.
 
 ## AWS Secrets Manager
 
-*AWS SecretsManager* (declared as `secretsmanager`): currently can only
-`distribute` secrets. `rotate` is only supported in conjunction with `bypass: true`
-for retrieval of existing secrets for the purposes of distribution to respective
-destinations.
+*AWS SecretsManager* (declared as `secretsmanager`): can `distribute` and/or `rotate` secrets.
+
+If `rotate`ing, a `config` section must be provided, with either `bypass: true` (pretend to 
+rotate, but don't really - just fetch the current password from the param) or `rotate_attribute: key` (specify the key in the JSON secret which holds the actual password value to rotate).
+
+Optionally, the `config` section can specify one or more of the following to control how new passwords are generated.
+   - length: int (32)
+   - exclude_char: str ('')
+   - exclude_num: bool (False)
+   - exclude_punct: bool (False)
+   - exclude_upper: bool (False)
+   - exclude_lower: bool (False)
+   - include_space: bool (False)
+   - require_each_type: bool (True)
 
 `secretsmanager` is _greedy_ in other words, it will take all that is provided
 by the `secret` and stick it into AWS SecretsManager. So no 1-1 mapping or
 cherry picking fragments.
 
 Uses client `AWS Secrets Manager`.
+
+## AWS Systems Manager Parameter Store
+
+*AWS SSM Parameter Store* (declared as `ssmparameterstore`): can `distribute` and/or `rotate` secrets. It
+exclusively uses SecureStrings to protect secrets, and currently only supports encryption using the default
+AWS Managed Key for Parameter Store.
+
+If `rotate`ing, a `config` section must be provided, with either `bypass: true` (pretend to 
+rotate, but don't really - just fetch the current password from the param) or `rotate_attribute: key` (specify the key in the JSON secret which holds the actual password value to rotate)
+
+Optionally, the `config` section can specify how new passwords are generated.
+
+Like `secretsmanager`, `ssmparameterstore` is _greedy_, and the `config` section can optionally specify how new passwords are generated. See above Secrets Manager section for details.
+
+Uses client `AWS SSM Parameter Store`.
 
 ## Bitbucket
 

--- a/src/keydra/clients/aws/ssmparameterstore.py
+++ b/src/keydra/clients/aws/ssmparameterstore.py
@@ -1,0 +1,119 @@
+import boto3
+import boto3.session
+
+from botocore.exceptions import ClientError
+
+
+class GetParameterException(Exception):
+    pass
+
+
+class PutParameterException(Exception):
+    pass
+
+
+class SSMClient(object):
+    def __init__(self, session=None, region_name=None, **kwargs):
+        if not session:
+            session = boto3.session.Session()
+
+        self._client = session.client(
+            service_name='ssm',
+            region_name=region_name
+        )
+
+    def parameter_exists(self, param_name) -> bool:
+        '''
+        Check if an SSM parameter exists
+
+        :param param_name: Name of the parameter
+        :type param_name: :class:`str`
+        :returns: True if exists, False if not
+        :rtype: :class:`bool`
+        '''
+        resp = self._client.describe_parameters(
+            ParameterFilters=[
+                {
+                    'Key': 'Name',
+                    'Values': [param_name],
+                }
+            ],
+            MaxResults=1
+        )
+        if len(resp['Parameters']) == 1:
+            return True
+
+        return False
+
+    def get_parameter_securestring_value(self, param_name) -> str:
+        '''
+        Retrieves a SecureString parameter from SSM by name
+
+        :param param_name: Name of the parameter
+        :type param_name: :class:`str`
+        :returns: The decrypted value stored in the parameter
+        :rtype: :class:`str`
+        '''
+        try:
+            resp = self._client.get_parameter(
+                Name=param_name,
+                WithDecryption=True,
+            )
+            return resp['Parameter']['Value']
+
+        except ClientError as e:
+            raise GetParameterException(
+                'Error fetching parameter {}: {}'.format(param_name, e)
+            )
+
+    def put_parameter_securestring(self, param_name, param_value, description,
+                                   tier='Standard', key_id=None) -> dict:
+        '''
+        Creates or Updates a SecureString parameter in SSM
+
+        :param param_name: Name (identifier) for the parameter
+        :type param_name: :class:`str`
+        :param param_value: Param value
+        :type param_value: :class:`str`
+        :param tier: :class:`str`
+        :type tier: (Optional) The tier to use ('Standard'|'Advanced'|'Intelligent-Tiering')
+        :param key_id: :class:`str`
+        :type key_id: (Optional) KMS Id to use for encryption. The default key is used if ommitted.
+        :returns: A dictonary with response (bypass from boto)
+        :rtype: :class:`dict`
+
+        Sample response:
+
+        {
+            'Version': 123,
+            'Tier': 'Standard'|'Advanced'|'Intelligent-Tiering'
+        }
+        '''
+        extras = {}
+        if key_id:
+            extras['KeyId'] = key_id
+
+        if self.parameter_exists(param_name):
+            extras['Overwrite'] = True
+
+        else:
+            extras['Description'] = description
+            extras['Tags'] = [
+                {
+                    'Key': 'managedby',
+                    'Value': 'keydra'
+                },
+            ]
+
+        try:
+            return self._client.put_parameter(
+                Name=param_name,
+                Value=param_value,
+                Type='SecureString',
+                Tier=tier,
+                **extras
+            )
+        except ClientError as e:
+            raise PutParameterException(
+                'Error creating/updating {}: {}'.format(param_name, e)
+            )

--- a/src/keydra/loader.py
+++ b/src/keydra/loader.py
@@ -28,14 +28,16 @@ LOCAL_PROVIDERS = {
     'appsync': 'aws_appsync',
     'firehose': 'aws_kinesisfirehose',
     'iam': 'aws_iam',
-    'secretsmanager': 'aws_secretsmanager'
+    'secretsmanager': 'aws_secretsmanager',
+    'ssmparameterstore': 'aws_ssmparameterstore'
 }
 
 LOCAL_CLIENTS = {
     'appsync': 'aws.appsync',
     'firehose': 'aws.kinesisfirehose',
     'iam': 'aws.iam',
-    'secretsmanager': 'aws.secretsmanager'
+    'secretsmanager': 'aws.secretsmanager',
+    'ssmparameterstore': 'aws.ssmparameterstore'
 }
 
 LOGGER = km_logging.get_logger()

--- a/src/keydra/providers/aws_ssmparameterstore.py
+++ b/src/keydra/providers/aws_ssmparameterstore.py
@@ -155,6 +155,10 @@ class SSMParameterProvider(BaseProvider):
         if 'source' in spec:
             return True, 'All good!'
 
+        if ('config' in spec):
+            if not (spec['config'].get('bypass') or spec['config'].get('rotate_attribute')):
+                return False, 'Must specify either "bypass" or "rotate_attribute" in the config'
+
         options = SSMParameterProvider.Options(**spec['config'])
 
         if options.bypass == (options.rotate_attribute is not None):

--- a/src/keydra/providers/aws_ssmparameterstore.py
+++ b/src/keydra/providers/aws_ssmparameterstore.py
@@ -1,0 +1,177 @@
+import boto3
+import boto3.session
+import json
+
+from keydra.providers.base import BaseProvider
+from keydra.providers.base import exponential_backoff_retry
+
+from keydra.exceptions import DistributionException
+
+from typing import Dict, NamedTuple, Optional
+from keydra.exceptions import RotationException
+
+from keydra.clients.aws.secretsmanager import SecretsManagerClient
+
+from keydra.clients.aws.ssmparameterstore import SSMClient
+from keydra.clients.aws.ssmparameterstore import PutParameterException
+
+from keydra.logging import get_logger
+
+
+LOGGER = get_logger()
+
+
+class SSMParameterProvider(BaseProvider):
+    def __init__(
+            self,
+            session=None,
+            client: SSMClient = None,
+            region_name=None,
+            # credentials must be present for the loader to init the provider
+            credentials=None):
+        if session is None:  # pragma: no cover
+            session = boto3.session.Session()
+
+        self._client = client or SSMClient(
+            session=session,
+            region_name=region_name
+        )
+        self._smclient = SecretsManagerClient(
+            session=session,
+            region_name=region_name
+        )
+
+    class Options(NamedTuple):
+        bypass: bool = False
+        rotate_attribute: Optional[str] = None
+        length: int = 32
+        exclude_char: str = ''
+        exclude_num: bool = False
+        exclude_punct: bool = False
+        exclude_upper: bool = False
+        exclude_lower: bool = False
+        include_space: bool = False
+        require_each_type: bool = True
+
+    def _distribute_secret(self, secret, dest):
+        try:
+            if self._client.parameter_exists(dest['key']):
+                LOGGER.info(
+                    '{} is present in SSM Parameter Store, updating.'.format(
+                        dest['key']
+                    )
+                )
+            else:
+                LOGGER.info(
+                    '{} not present in SSM Parameter Store, adding.'.format(
+                        dest['key'],
+                    )
+                )
+
+            self._client.put_parameter_securestring(
+                param_name=dest['key'],
+                param_value=json.dumps(secret),
+                description='Keydra managed secret {}'.format(
+                    dest['key']
+                )
+            )
+
+        except PutParameterException as e:
+            raise DistributionException(
+                'Error distributing {}: {}'.format(dest['key'], e)
+            )
+
+        LOGGER.info(
+            'Successfully distributed {} to SSM Parameter Store'.format(
+                dest['key']
+            )
+        )
+
+        return dest
+
+    def _get_current_secret(self, secret_key):
+        try:
+            value = self._client.get_parameter_securestring_value(secret_key)
+
+            # Assume that all secret values are formatted as valid JSON objects
+            obj = json.loads(value)
+            obj['provider'] = 'ssmparameterstore'
+
+            return obj
+
+        except Exception as e:
+            raise RotationException(e)
+
+    def _generate_secret_value(self, opts: Options) -> str:
+        return self._smclient.generate_random_password(
+            length=opts.length,
+            ExcludeCharacters=opts.exclude_char,
+            ExcludeNumbers=opts.exclude_num,
+            ExcludePunctuation=opts.exclude_punct,
+            ExcludeUppercase=opts.exclude_upper,
+            ExcludeLowercase=opts.exclude_lower,
+            IncludeSpace=opts.include_space,
+            RequireEachIncludedType=opts.require_each_type)
+
+    def rotate(self, spec) -> Dict[str, str]:
+        current_secret = self._get_current_secret(spec['key'])
+
+        options = SSMParameterProvider.Options(**spec['config'])
+
+        if options.bypass:
+            LOGGER.debug('Bypassing rotation for {}'.format(spec['key']))
+            return current_secret
+
+        LOGGER.debug('Rotating {} with options: {}'
+                     .format(spec['key'], options))
+
+        current_secret[options.rotate_attribute] = \
+            self._generate_secret_value(options)
+
+        self._client.put_parameter_securestring(
+                param_name=spec['key'],
+                param_value=json.dumps(current_secret),
+                description=''
+        )
+        return current_secret
+
+    @exponential_backoff_retry(3)
+    def distribute(self, secret, destination):
+        try:
+            return self._distribute_secret(secret, destination)
+        except Exception as e:
+            raise DistributionException(e)
+
+    @classmethod
+    def validate_spec(cls, spec):
+        valid, msg = BaseProvider.validate_spec(spec)
+
+        if not valid:
+            return False, msg
+
+        if ('config' in spec) == ('source' in spec):
+            return False, 'Must specify either "config" or "source", not both'
+
+        if 'source' in spec:
+            return True, 'All good!'
+
+        options = SSMParameterProvider.Options(**spec['config'])
+
+        if options.bypass == (options.rotate_attribute is not None):
+            return False, 'Must specify either "bypass" or \
+                "rotate_attribute", not both'
+
+        return True, 'All good!'
+
+    @classmethod
+    def redact_result(cls, result, spec=None):
+        if 'value' in result:
+            for key, value in result['value'].items():
+                if key != 'provider':
+                    result['value'][key] = '***'
+
+        return result
+
+    @classmethod
+    def has_creds(cls):
+        return False

--- a/tests/test_client_aws_ssmparameterstore.py
+++ b/tests/test_client_aws_ssmparameterstore.py
@@ -1,0 +1,142 @@
+import unittest
+
+from botocore.exceptions import ClientError
+
+from keydra.clients.aws.ssmparameterstore import SSMClient
+from keydra.clients.aws.ssmparameterstore import GetParameterException, PutParameterException
+
+from unittest.mock import MagicMock
+
+
+CLIENT_ERR = ClientError(
+    error_response={'Error': {'Code': 'boom'}},
+    operation_name='opiv'
+)
+
+
+class TestSSMParamStoreClient(unittest.TestCase):
+    def test__describe_parameters(self):
+        cli = SSMClient(session=MagicMock())
+        cli._client.describe_parameters = MagicMock()
+
+        cli._client.describe_parameters.return_value = {
+            'Parameters': [1]
+        }
+        self.assertEqual(cli.parameter_exists('woot'), True)
+
+        cli._client.describe_parameters.return_value = {
+            'Parameters': []
+        }
+        self.assertEqual(cli.parameter_exists('woot'), False)
+
+    def test__get_param_success(self):
+        cli = SSMClient(session=MagicMock())
+        cli._client.get_parameter = MagicMock()
+
+        cli._client.get_parameter.return_value = {
+            'Parameter': {'Value': 'wootytooty'}
+        }
+        self.assertEqual(cli.get_parameter_securestring_value('woot'), 'wootytooty')
+
+    def test__get_param_fail(self):
+        cli = SSMClient(session=MagicMock())
+        cli._client.get_parameter = MagicMock()
+        cli._client.get_parameter.side_effect = CLIENT_ERR
+
+        with self.assertRaises(GetParameterException):
+            cli.get_parameter_securestring_value('woot')
+
+    def test__put_param_success_param_exists(self):
+        cli = SSMClient(session=MagicMock())
+        cli._client = MagicMock()
+
+        cli._client.put_parameter = MagicMock()
+
+        cli.parameter_exists = MagicMock(return_value=True)
+
+        api_resp = {
+            'Version': 123,
+            'Tier': 'Standard'
+        }
+
+        cli._client.put_parameter.return_value = api_resp
+
+        self.assertEqual(
+            cli.put_parameter_securestring(
+                param_name='woot',
+                param_value='toot',
+                description='Some stuff'
+            ),
+            api_resp
+        )
+        cli._client.put_parameter.assert_called_once_with(
+            Name='woot', Value='toot', Type='SecureString', Tier='Standard', Overwrite=True
+        )
+
+    def test__put_param_fail(self):
+        cli = SSMClient(session=MagicMock())
+        cli._client.put_parameter = MagicMock()
+        cli._client.put_parameter.side_effect = CLIENT_ERR
+
+        with self.assertRaises(PutParameterException):
+            cli.put_parameter_securestring(
+                param_name='woot',
+                param_value='toot',
+                description='Some stuff'
+            )
+
+    def test__put_param_success_param_not_exists(self):
+        cli = SSMClient(session=MagicMock())
+        cli._client = MagicMock()
+
+        cli._client.put_parameter = MagicMock()
+
+        cli.parameter_exists = MagicMock(return_value=False)
+
+        api_resp = {
+            'Version': 123,
+            'Tier': 'Standard'
+        }
+
+        cli._client.put_parameter.return_value = api_resp
+
+        self.assertEqual(
+            cli.put_parameter_securestring(
+                param_name='woot',
+                param_value='toot',
+                description='Some stuff'
+            ),
+            api_resp
+        )
+        cli._client.put_parameter.assert_called_once_with(
+            Name='woot',
+            Value='toot',
+            Type='SecureString',
+            Tier='Standard',
+            Description='Some stuff',
+            Tags=[{'Key': 'managedby', 'Value': 'keydra'}]
+        )
+
+    def test__put_param_specify_key(self):
+        cli = SSMClient(session=MagicMock())
+        cli._client = MagicMock()
+
+        cli._client.put_parameter = MagicMock()
+
+        cli.parameter_exists = MagicMock(return_value=False)
+        cli.put_parameter_securestring(
+            param_name='woot',
+            param_value='toot',
+            description='Some stuff',
+            key_id='test'
+        )
+
+        cli._client.put_parameter.assert_called_once_with(
+            Name='woot',
+            Value='toot',
+            Type='SecureString',
+            Tier='Standard',
+            KeyId='test',
+            Description='Some stuff',
+            Tags=[{'Key': 'managedby', 'Value': 'keydra'}]
+        )

--- a/tests/test_provider_aws_ssmparameterstore.py
+++ b/tests/test_provider_aws_ssmparameterstore.py
@@ -1,0 +1,276 @@
+import json
+import unittest
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from keydra.exceptions import DistributionException, RotationException
+
+from keydra.clients.aws.ssmparameterstore import PutParameterException, GetParameterException
+from keydra.providers.aws_ssmparameterstore import SSMParameterProvider
+
+IAM_SECRET = {
+    'key': 'secret_key',
+    'secret': 'secret_secret',
+    'provider': 'iam'
+}
+
+SSM_DEST = {
+    'key': 'secret_name',
+    'provider': 'ssmparameterstore'
+}
+
+
+class TestProviderAWSSSMParameterStore(unittest.TestCase):
+    def test__distribute_secret_new_key(self):
+        cli = SSMParameterProvider(session=MagicMock())
+
+        cli._client = MagicMock()
+        cli._client.parameter_exists.return_value = False
+
+        cli._distribute_secret(IAM_SECRET, SSM_DEST)
+
+        cli._client.parameter_exists.assert_called_once_with(
+            SSM_DEST['key']
+        )
+        cli._client.put_parameter_securestring.assert_called_once_with(
+            param_name=SSM_DEST['key'],
+            param_value=json.dumps(IAM_SECRET),
+            description='Keydra managed secret {}'.format(SSM_DEST['key'])
+        )
+
+    def test__distribute_secret_existing_key(self):
+        cli = SSMParameterProvider(session=MagicMock())
+
+        cli._client = MagicMock()
+        cli._client.parameter_exists.return_value = True
+
+        cli._distribute_secret(IAM_SECRET, SSM_DEST)
+
+        cli._client.parameter_exists.assert_called_once_with(
+            SSM_DEST['key']
+        )
+        cli._client.put_parameter_securestring.assert_called_once_with(
+            param_name=SSM_DEST['key'],
+            param_value=json.dumps(IAM_SECRET),
+            description='Keydra managed secret {}'.format(SSM_DEST['key'])
+        )
+
+    def test__raise_on_failed_update(self):
+        cli = SSMParameterProvider(session=MagicMock())
+
+        cli._client = MagicMock()
+        cli._client.parameter_exists.return_value = True
+        cli._client.put_parameter_securestring.side_effect = PutParameterException
+
+        with self.assertRaises(DistributionException):
+            cli._distribute_secret(IAM_SECRET, SSM_DEST)
+
+    def test_distribute(self):
+        cli = SSMParameterProvider(session=MagicMock())
+
+        with patch.object(cli, '_distribute_secret') as mk_ds:
+            cli.distribute(IAM_SECRET, SSM_DEST)
+
+            mk_ds.assert_called_once_with(IAM_SECRET, SSM_DEST)
+
+    def test_rotate_no_bypass(self):
+        # Arrange
+        cli = SSMParameterProvider(session=MagicMock(), client=MagicMock())
+        cli._client.get_parameter_securestring_value.return_value = json.dumps({
+            'a': 'not-rotated', 'the_secret_attribute': 'old-val'})
+        cli._smclient = MagicMock()
+        cli._smclient.generate_random_password.return_value = 'new-val'
+
+        spec = {
+            'key': 'secret_name',
+            'provider': 'ssmparameterstore',
+            'config': SSMParameterProvider.Options(
+                rotate_attribute='the_secret_attribute')._asdict()
+        }
+
+        # Act
+        return_val = cli.rotate(spec)
+
+        # Assert
+        self.assertEqual(return_val, {
+            'a': 'not-rotated',
+            'the_secret_attribute': 'new-val',
+            'provider': 'ssmparameterstore'})
+
+        cli._client.get_parameter_securestring_value.assert_called_once_with(spec['key'])
+        cli._smclient.generate_random_password.assert_called_once_with(
+            length=32,
+            ExcludeCharacters='',
+            ExcludeNumbers=False,
+            ExcludePunctuation=False,
+            ExcludeUppercase=False,
+            ExcludeLowercase=False,
+            IncludeSpace=False,
+            RequireEachIncludedType=True,
+        )
+
+        cli._client.put_parameter_securestring.assert_called_once_with(
+            param_name=spec['key'],
+            param_value=json.dumps(return_val),
+            description='',
+        )
+
+    def test_rotate_cant_get_current(self):
+        cli = SSMParameterProvider(session=MagicMock(), client=MagicMock())
+        cli._client.get_parameter_securestring_value.side_effect = GetParameterException
+
+        spec = {
+            'key': 'secret_name',
+            'provider': 'secretsmanager',
+            'config': SSMParameterProvider.Options(
+                rotate_attribute='the_secret_attribute')._asdict()
+        }
+
+        with self.assertRaises(RotationException):
+            cli.rotate(spec)
+
+        cli._client.get_parameter_securestring_value.assert_called_once_with(spec['key'])
+
+    def test_rotate_no_bypass_override_generated_pass_options(self):
+        # Arrange
+        cli = SSMParameterProvider(session=MagicMock(), client=MagicMock())
+        cli._client.get_parameter_securestring_value.return_value = json.dumps({
+            'a': 'not-rotated', 'the_secret_attribute': 'old-val'})
+
+        cli._smclient = MagicMock()
+        cli._smclient.generate_random_password.return_value = 'new-val'
+
+        spec = {
+            'key': 'secret_name',
+            'provider': 'secretsmanager',
+            'config': SSMParameterProvider.Options(
+                rotate_attribute='the_secret_attribute',
+                exclude_char='abc',
+                exclude_lower=True,
+                exclude_upper=True,
+                exclude_num=True,
+                exclude_punct=True,
+                include_space=True,
+                length=12,
+                require_each_type=False
+            )._asdict()
+        }
+
+        # Act
+        return_val = cli.rotate(spec)
+
+        # Assert
+        cli._smclient.generate_random_password.assert_called_once_with(
+            length=12,
+            ExcludeCharacters='abc',
+            ExcludeNumbers=True,
+            ExcludePunctuation=True,
+            ExcludeUppercase=True,
+            ExcludeLowercase=True,
+            IncludeSpace=True,
+            RequireEachIncludedType=False,
+        )
+
+        cli._client.put_parameter_securestring.assert_called_once_with(
+            param_name=spec['key'],
+            param_value=json.dumps(return_val),
+            description='',
+        )
+
+    def test_rotate_with_bypass(self):
+        cli = SSMParameterProvider(session=MagicMock())
+        cli._client = MagicMock()
+        cli._client.get_parameter_securestring_value.return_value = json.dumps({
+            'key1': 'val1'
+        })
+
+        result = cli.rotate({
+            'key': 'secret_name',
+            'provider': 'ssmparameterstore',
+            'config': {
+                'bypass': True
+            }
+        })
+
+        self.assertEqual(result, {
+            'key1': 'val1',
+            'provider': 'ssmparameterstore'
+        })
+        cli._client.get_parameter_securestring_value.assert_called_once_with('secret_name')
+
+    def test_validate_spec_base_fail(self):
+        speci_valid = {
+            'missing-provider': 'bananas',
+            'key': 'abc'
+        }
+
+        r_result = SSMParameterProvider.validate_spec(speci_valid)
+        self.assertEqual(r_result[0], False)
+
+    def test_validate_spec_no_config(self):
+        speci_valid = {
+            'provider': 'ssmparameterstore',
+            'key': 'abc'
+        }
+
+        r_result = SSMParameterProvider.validate_spec(speci_valid)
+        self.assertEqual(r_result[0], False)
+
+    def test_validate_spec_has_bypass_and_attr_name(self):
+        speci_valid = {
+            'provider': 'ssmparameterstore',
+            'key': 'abc',
+            'config': SSMParameterProvider.Options(
+                bypass=True,
+                rotate_attribute='my_pass'
+            )._asdict()
+        }
+
+        r_result = SSMParameterProvider.validate_spec(speci_valid)
+        self.assertEqual(r_result[0], False)
+
+    def test_validate_spec_with_source(self):
+        speci_valid = {
+            'provider': 'ssmparameterstore',
+            'key': 'abc',
+            'source': 'bananas'
+        }
+
+        r_result = SSMParameterProvider.validate_spec(speci_valid)
+        self.assertEqual(r_result[0], True)
+
+    def test_validate_spec_with_rotate_attribute(self):
+        speci_valid = {
+            'provider': 'ssmparameterstore',
+            'key': 'abc',
+            'config': {
+                'rotate_attribute': 'my_pass',
+                'length': 123
+            }
+        }
+
+        r_result = SSMParameterProvider.validate_spec(speci_valid)
+        self.assertEqual(r_result[0], True)
+
+    def test_redact_result(self):
+        result = {
+            'status': 'success',
+            'action': 'rotate_secret',
+            'value': {
+                'provider': 'cloudflare',
+                'a': '1',
+                'b': '2'
+            }
+        }
+
+        r_result = SSMParameterProvider.redact_result(result)
+        self.assertEqual(r_result, {
+            'status': 'success',
+            'action': 'rotate_secret',
+            'value': {
+                'provider': 'cloudflare',
+                'a': '***',
+                'b': '***'
+            }
+        })

--- a/tests/test_provider_aws_ssmparameterstore.py
+++ b/tests/test_provider_aws_ssmparameterstore.py
@@ -253,6 +253,18 @@ class TestProviderAWSSSMParameterStore(unittest.TestCase):
         r_result = SSMParameterProvider.validate_spec(speci_valid)
         self.assertEqual(r_result[0], True)
 
+    def test_validate_spec_missing_required_config(self):
+        speci_valid = {
+            'provider': 'ssmparameterstore',
+            'key': 'abc',
+            'config': {
+                'length': 123
+            }
+        }
+
+        r_result = SSMParameterProvider.validate_spec(speci_valid)
+        self.assertEqual(r_result[0], False)
+
     def test_redact_result(self):
         result = {
             'status': 'success',


### PR DESCRIPTION
From where I sit, the security of secrets in AWS Secrets Manager is about the same as SSM Parameter Store `SecureStrings`, at least in the way they are used by Keydra. `SecureStrings` are encrypted (with KMS), protected from being exposed in logs etc, and access control with IAM works the same way as Secrets Manager - they just cost less!

There are some size restrictions with SSM Params (4kB?) which might mean Secrets Manager is still better for some use cases, but in the interest of giving people a choice, this change adds a new SSM Parameter Store provider, which exclusively uses `SecureStrings` for our required level of secret protection.

The new provider has been designed to work the same as the existing Secrets Manager provider, so as to function as a drop in replacement for people wanting those sweet $$$ savings without the fuss. 🤑 

Tests and documentation included! 💪 