### PR TITLE
Feature/batching keydra runs

### DIFF
--- a/docs/content/examples/batchingruns.md
+++ b/docs/content/examples/batchingruns.md
@@ -1,0 +1,60 @@
+---
+title: "Batching Keydra Runs to avoid lambda timeout"
+date: 2022-11-16T14:03:08+11:00
+draft: false
+---
+
+Example to set up an AWS Event Rule in a serverless yaml file for a daily rotation splitting the runs into batches. 
+This option was made available due to the 15-minute timeout cap on AWS Lambda. 
+So if there were too many secrets such that the Keydra lambda function would time out during the rotation run, 
+the batching option would be available to split the run into batches.
+
+The example below splits the scheduled run into 2 batches 
+and each schedule will run one half of the batch depending on which `batch_number` was given in the input.
+The batch number starts at 0 up to the `number_of_batches` - 1.
+
+I.e. If `number_of_batches: 2`, `batch_number: 0` will run the first half of the secrets 
+and `batch_number: 1` will run the second half
+
+```yaml
+Resources:
+  Keydra:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: keydra
+      Description: Keydra - safe and lightweight management of secrets
+      CodeUri: src/
+      Handler: app.lambda_handler
+      Runtime: python3.7
+      MemorySize: 256
+      Role: !Sub "<IAM Role Arn>"
+      Environment:
+        Variables:
+          KEYDRA_CFG_PROVIDER: bitbucket, github or gitlab
+          KEYDRA_CFG_CONFIG_ACCOUNTUSERNAME: <bb account name or github org name, unused for gitlab>
+          KEYDRA_CFG_CONFIG_SECRETS_REPOSITORY: <secrets repo name>
+          KEYDRA_CFG_CONFIG_SECRETS_REPOSITORYBRANCH: <repo branch to fetch secrets from (gitlab only)>
+          KEYDRA_CFG_CONFIG_SECRETS_PATH: <path to secrets.yaml>
+          KEYDRA_CFG_CONFIG_SECRETS_FILETYPE: yaml
+          KEYDRA_CFG_CONFIG_ENVIRONMENTS_REPOSITORY: <environments repo name>
+          KEYDRA_CFG_CONFIG_ENVIRONMENTS_REPOSITORYBRANCH: <repo branch to fetch environments from (gitlab only)>
+          KEYDRA_CFG_CONFIG_ENVIRONMENTS_PATH: <path to environments.yaml>
+          KEYDRA_CFG_CONFIG_ENVIRONMENTS_FILETYPE: yaml
+      Events:
+        KeydraNightlyFirstBatch:
+          Type: Schedule
+          Properties:
+            Schedule: "cron(0 12 ? * * *)"
+            Name: keydra-nightly-first-batch
+            Description: Keydra nightly key rotation
+            Input: '{"trigger": "nightly", "batch_number": 0, "number_of_batches: 2}'
+            Enabled: true
+        KeydraNightlySecondBatch:
+          Type: Schedule
+          Properties:
+            Schedule: "cron(0 12 ? * * *)"
+            Name: keydra-nightly-second-batch
+            Description: Keydra nightly key rotation
+            Input: '{"trigger": "nightly", "batch_number": 1, "number_of_batches: 2}'
+            Enabled: true
+```

--- a/docs/content/examples/batchingruns.md
+++ b/docs/content/examples/batchingruns.md
@@ -14,7 +14,7 @@ and each schedule will run one half of the batch depending on which `batch_numbe
 
 `number_of_batches` represents the amount of groups the Keydra secrets will be split into
 
-`batch_number` represents the which group is run. `batch_number` starts at 0 up to `number_of_batches` - 1.
+`batch_number` represents which group is run. `batch_number` starts at 0 up to `number_of_batches` - 1.
 
 I.e. If `number_of_batches: 2`, `batch_number: 0` will run the first half of the secrets 
 and `batch_number: 1` will run the second half

--- a/docs/content/examples/batchingruns.md
+++ b/docs/content/examples/batchingruns.md
@@ -1,6 +1,6 @@
 ---
 title: "Batching Keydra Runs to avoid lambda timeout"
-date: 2022-11-16T14:03:08+11:00
+date: 2022-11-16T12:03:08+11:00
 draft: false
 ---
 
@@ -11,10 +11,15 @@ the batching option would be available to split the run into batches.
 
 The example below splits the scheduled run into 2 batches 
 and each schedule will run one half of the batch depending on which `batch_number` was given in the input.
-The batch number starts at 0 up to the `number_of_batches` - 1.
+
+`number_of_batches` represents the amount of groups the Keydra secrets will be split into
+
+`batch_number` represents the which group is run. `batch_number` starts at 0 up to `number_of_batches` - 1.
 
 I.e. If `number_of_batches: 2`, `batch_number: 0` will run the first half of the secrets 
 and `batch_number: 1` will run the second half
+
+
 
 ```yaml
 Resources:

--- a/docs/data/menu/main.yaml
+++ b/docs/data/menu/main.yaml
@@ -25,6 +25,8 @@ main:
       ref: "/examples/githubactionsawsdeployment"
     - name: Gitlab AWS Deployment Credentials
       ref: "/examples/gitlabawsdeployment"
+    - name: Batching Keydra Runs to avoid lambda timeout
+      ref: "/examples/batchingruns"
   - name: Developing
     ref: "/develop"
     sub:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 Authlib==0.14.3
 boto3==1.17.85
 botocore==1.20.85
-cffi==1.14.0
+cffi==1.15.1
 coverage==5.0.4
-cryptography==3.3.2
+cryptography==38.0.3
 decorator==4.4.2
 docutils==0.16.0
 entrypoints==0.3

--- a/src/app.py
+++ b/src/app.py
@@ -125,6 +125,8 @@ def lambda_handler(event, context):
     trigger = event.get('trigger', 'nightly')
     run_for_secrets = event.get('secrets', None)
     debug_mode = event.get('debug', False)
+    batch_number = event.get('batch_number', None)
+    number_of_batches = event.get('number_of_batches', None)
 
     if debug_mode:
         LOGGER.setLevel(logging.DEBUG)
@@ -139,7 +141,7 @@ def lambda_handler(event, context):
     )
 
     resp = Keydra(_load_keydra_config(), CW).rotate_and_distribute(
-        run_for_secrets=run_for_secrets, rotate=trigger)
+        run_for_secrets=run_for_secrets, rotate=trigger, batch_number=batch_number, number_of_batches=number_of_batches)
 
     LOGGER.info(
         {

--- a/src/keydra/config.py
+++ b/src/keydra/config.py
@@ -128,22 +128,20 @@ class KeydraConfig(object):
 
         candidate_secrets = specs
 
-        if number_of_batches is not None and batch_number is not None:
+        if number_of_batches is not None and batch_number is not None and rotate == 'nightly':
             if not isinstance(number_of_batches, int) or not isinstance(batch_number, int):
                 raise Exception(
                     f"batch number {batch_number} or number of batches {number_of_batches} is not an integer")
-
             if batch_number >= number_of_batches or number_of_batches <= 0 or batch_number < 0:
-                raise Exception(f"batch number {batch_number} and number of batches {batch_number} is not valid")
+                raise Exception(
+                    f"batch number {batch_number} of number of batches {batch_number} are not valid numbers")
             batch_size = math.ceil(len(candidate_secrets) / number_of_batches)
             starting_index = batch_size * batch_number  # assumption that batch number starts from zero
-            if rotate == 'nightly':
-                # Only rotate the first batch of secrets
-                LOGGER.info(
-                    'Batching batch number %s, batch size of %s, number of batches %s, secrets for nightly rotation',
-                    batch_number, batch_size, number_of_batches)
-                candidate_secrets = dict((k, v) for k, v in list(
-                    candidate_secrets.items())[starting_index: starting_index + batch_size])
+            LOGGER.info(
+                'Batching batch number %s, batch size of %s, number of batches %s, secrets for nightly rotation',
+                batch_number, batch_size, number_of_batches)
+            candidate_secrets = dict((k, v) for k, v in list(
+                candidate_secrets.items())[starting_index: starting_index + batch_size])
 
         for sid, secret in candidate_secrets.items():
             if requested_secrets and sid not in requested_secrets:

--- a/src/keydra/config.py
+++ b/src/keydra/config.py
@@ -1,4 +1,5 @@
 import copy
+import math
 
 from keydra import loader
 
@@ -6,6 +7,7 @@ from keydra.exceptions import ConfigException
 from keydra.exceptions import InvalidSecretProvider
 
 from keydra.logging import get_logger
+
 
 
 KEYDRA_CONFIG_REPO = 'keydra-config'
@@ -116,7 +118,7 @@ class KeydraConfig(object):
                               .format(account_id))
 
     def _filter(self, environments, specs, rotate='adhoc',
-                requested_secrets=None, batch_size=None):
+                requested_secrets=None, number_of_batches:int=None, batch_number:int=None):
         filtered_secrets = []
         current_env_name = self._guess_current_environment(environments)
         current_env = environments[current_env_name]
@@ -128,21 +130,20 @@ class KeydraConfig(object):
 
         candidate_secrets = specs
 
-        if batch_size:
+        if number_of_batches is not None and batch_number is not None:
+            if not isinstance(number_of_batches, int) or not isinstance(batch_number, int):
+                raise Exception(f"batch number {batch_number} or number of batches {number_of_batches} is not an integer")
+
+            if batch_number >= number_of_batches or number_of_batches <= 0 or batch_number < 0:
+                raise Exception(f"batch number {batch_number} and number of batches {batch_number} is not valid")
+            batch_size = math.ceil(len(candidate_secrets)/number_of_batches)
+            starting_index = batch_size * batch_number # assumption that batch number starts from zero
             if rotate == 'nightly':
                 # Only rotate the first batch of secrets
                 LOGGER.info(
-                    'Batching the first {} secrets for nightly rotation'.format(batch_size))
+                    'Batching batch number %s, batch size of %s, number of batches %s, secrets for nightly rotation', batch_number, batch_size, number_of_batches)
                 candidate_secrets = dict((k, v) for k, v in list(
-                    candidate_secrets.items())[:batch_size])
-            elif rotate == 'nightly-secondary':
-                LOGGER.info('Skipping the first {} secrets and taking '
-                            'the rest for secondary nightly rotation'.
-                            format(batch_size))
-                # Rotate the second batch of secrets, skipping the first batch
-                candidate_secrets = dict((k, v) for k, v in list(
-                    candidate_secrets.items())[batch_size:])
-                rotate = 'nightly'  # Pick up secrets marked for nightly rotation
+                    candidate_secrets.items())[starting_index: starting_index+batch_size])
 
         for sid, secret in candidate_secrets.items():
             if requested_secrets and sid not in requested_secrets:
@@ -213,7 +214,7 @@ class KeydraConfig(object):
 
         return filtered_secrets
 
-    def load_secrets(self, rotate='nightly', secrets=None):
+    def load_secrets(self, rotate='nightly', secrets=None, batch_number=None, number_of_batches=None):
         LOGGER.info(
             'Attempting to load secrets ({}) from {}'.format(
                 ', '.join(secrets) if secrets else 'ALL',
@@ -230,10 +231,7 @@ class KeydraConfig(object):
 
         return self._filter(
             *config,
-            batch_size=50
-            if self._config.get('batchnightlysecrets', False)
-            else None,
-            rotate=rotate, requested_secrets=secrets)
+            rotate=rotate, requested_secrets=secrets, batch_number=batch_number, number_of_batches=number_of_batches)
 
     def get_accountusername(self):
         '''

--- a/src/keydra/config.py
+++ b/src/keydra/config.py
@@ -8,8 +8,6 @@ from keydra.exceptions import InvalidSecretProvider
 
 from keydra.logging import get_logger
 
-
-
 KEYDRA_CONFIG_REPO = 'keydra-config'
 
 REMOTE_CONFIG_ENVS = 'src/main/dist/environments.yaml'
@@ -118,7 +116,7 @@ class KeydraConfig(object):
                               .format(account_id))
 
     def _filter(self, environments, specs, rotate='adhoc',
-                requested_secrets=None, number_of_batches:int=None, batch_number:int=None):
+                requested_secrets=None, number_of_batches: int = None, batch_number: int = None):
         filtered_secrets = []
         current_env_name = self._guess_current_environment(environments)
         current_env = environments[current_env_name]
@@ -132,18 +130,20 @@ class KeydraConfig(object):
 
         if number_of_batches is not None and batch_number is not None:
             if not isinstance(number_of_batches, int) or not isinstance(batch_number, int):
-                raise Exception(f"batch number {batch_number} or number of batches {number_of_batches} is not an integer")
+                raise Exception(
+                    f"batch number {batch_number} or number of batches {number_of_batches} is not an integer")
 
             if batch_number >= number_of_batches or number_of_batches <= 0 or batch_number < 0:
                 raise Exception(f"batch number {batch_number} and number of batches {batch_number} is not valid")
-            batch_size = math.ceil(len(candidate_secrets)/number_of_batches)
-            starting_index = batch_size * batch_number # assumption that batch number starts from zero
+            batch_size = math.ceil(len(candidate_secrets) / number_of_batches)
+            starting_index = batch_size * batch_number  # assumption that batch number starts from zero
             if rotate == 'nightly':
                 # Only rotate the first batch of secrets
                 LOGGER.info(
-                    'Batching batch number %s, batch size of %s, number of batches %s, secrets for nightly rotation', batch_number, batch_size, number_of_batches)
+                    'Batching batch number %s, batch size of %s, number of batches %s, secrets for nightly rotation',
+                    batch_number, batch_size, number_of_batches)
                 candidate_secrets = dict((k, v) for k, v in list(
-                    candidate_secrets.items())[starting_index: starting_index+batch_size])
+                    candidate_secrets.items())[starting_index: starting_index + batch_size])
 
         for sid, secret in candidate_secrets.items():
             if requested_secrets and sid not in requested_secrets:

--- a/src/keydra/config.py
+++ b/src/keydra/config.py
@@ -138,7 +138,7 @@ class KeydraConfig(object):
             batch_size = math.ceil(len(candidate_secrets) / number_of_batches)
             starting_index = batch_size * batch_number  # assumption that batch number starts from zero
             LOGGER.info(
-                'Batching batch number %s, batch size of %s, number of batches %s, secrets for nightly rotation',
+                'Batching batch number %s, batch size of %s, number of batches %s, secrets for rotation',
                 batch_number, batch_size, number_of_batches)
             candidate_secrets = dict((k, v) for k, v in list(
                 candidate_secrets.items())[starting_index: starting_index + batch_size])

--- a/src/keydra/config.py
+++ b/src/keydra/config.py
@@ -128,7 +128,7 @@ class KeydraConfig(object):
 
         candidate_secrets = specs
 
-        if number_of_batches is not None and batch_number is not None and rotate == 'nightly':
+        if number_of_batches is not None and batch_number is not None:
             if not isinstance(number_of_batches, int) or not isinstance(batch_number, int):
                 raise Exception(
                     f"batch number {batch_number} or number of batches {number_of_batches} is not an integer")

--- a/src/keydra/keydra.py
+++ b/src/keydra/keydra.py
@@ -17,7 +17,7 @@ class Keydra(object):
         self._cfg = cfg
         self._cw = cw
 
-    def rotate_and_distribute(self, run_for_secrets, rotate):
+    def rotate_and_distribute(self, run_for_secrets, rotate, batch_number=None, number_of_batches=None):
         '''
         AWS Lambda handler
 
@@ -34,7 +34,7 @@ class Keydra(object):
 
         try:
             secrets = self._cfg.load_secrets(
-                secrets=run_for_secrets, rotate=rotate)
+                secrets=run_for_secrets, rotate=rotate, batch_number=batch_number, number_of_batches=number_of_batches)
         except ConfigException as e:
             LOGGER.error(e)
             return [self._fail(e)]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -272,15 +272,6 @@ class TestConfig(unittest.TestCase):
         all_secrets = {}
         envs = {"dev": {"secrets": []}}
 
-        for i in range(1, 11):
-            secret_id = "secret" + str(i)
-            all_secrets[secret_id] = {
-                "key": "km_secret",
-                "provider": "IAM",
-                "rotate": "nightly",
-            }
-            envs["dev"]["secrets"].append(str(secret_id))
-
         with patch.object(self.client, "_guess_current_environment") as mk_gce:
             mk_gce.return_value = "dev"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -247,9 +247,7 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(filtered[0]["distribute"][0]["provider"], "secretsmanager")
 
             mk_gce.return_value = "dev"
-            filtered = self.client._filter(
-                ENVS, SECRETS_S, rotate="adhoc", requested_secrets=["splunk"]
-            )
+            filtered = self.client._filter(ENVS, SECRETS_S, rotate="adhoc", requested_secrets=["splunk"])
             self.assertEqual(len(filtered), 1)
             self.assertEqual(filtered[0]["key"], "splunk")
             self.assertEqual(filtered[0]["distribute"][0]["provider"], "secretsmanager")
@@ -292,11 +290,11 @@ class TestConfig(unittest.TestCase):
 
     def test_filter_nightly_with_invalid_batch_input(self):
         # test parameters are number of batches, batch number
-        invalid_integer_exception_regex = "batch number -?\d+ of number of batches -?\d+ are not valid numbers"
-        invalid_type_exception_regex = "batch number .* or number of batches .* is not an integer"
+        invalid_integer_exception_regex = r"batch number -?\d+ of number of batches -?\d+ are not valid numbers"
+        invalid_type_exception_regex = r"batch number .* or number of batches .* is not an integer"
         batch_parameters = [
             (0, 0, invalid_integer_exception_regex),  # zero batches
-            (2, 2, invalid_integer_exception_regex),  # 2 batches, trying to fetch batch number 2, batch number starts at 0
+            (2, 2, invalid_integer_exception_regex),  # 2 batches, trying to fetch batch number 2, only 0,1 are valid
             (2, 4, invalid_integer_exception_regex),  # 2 batches, trying to fetch a batch number that is out pf range
             (1, -1, invalid_integer_exception_regex),  # negative batch number
             (-1, 1, invalid_integer_exception_regex),  # negative number of batches

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,179 +10,139 @@ from unittest.mock import patch
 
 
 ENVS = {
-    'dev': {
-        'description': 'AWS Development Environment',
-        'type': 'aws',
-        'access': 'dev',
-        'id': '001122',
-        'secrets': [
-            'aws_deployments',
-            'splunk',
-            'aws_deployment_just_rotate',
-            'cloudflare_canary',
-            'okta_canary',
-            'office365_adhoc',
-        ]
+    "dev": {
+        "description": "AWS Development Environment",
+        "type": "aws",
+        "access": "dev",
+        "id": "001122",
+        "secrets": [
+            "aws_deployments",
+            "splunk",
+            "aws_deployment_just_rotate",
+            "cloudflare_canary",
+            "okta_canary",
+            "office365_adhoc",
+        ],
     },
-    'uat': {
-        'description': 'AWS UAT Environment',
-        'type': 'aws',
-        'access': 'uat',
-        'id': '334455',
-        'secrets': ['aws_deployments']
+    "uat": {
+        "description": "AWS UAT Environment",
+        "type": "aws",
+        "access": "uat",
+        "id": "334455",
+        "secrets": ["aws_deployments"],
     },
-    'prod': {
-        'description': 'AWS Prod Environment',
-        'type': 'aws',
-        'access': 'production',
-        'id': 667788,
-        'secrets': ['aws_deployments']
+    "prod": {
+        "description": "AWS Prod Environment",
+        "type": "aws",
+        "access": "production",
+        "id": 667788,
+        "secrets": ["aws_deployments"],
     },
-    'control': {
-        'description': 'AWS Master Environment',
-        'type': 'aws',
-        'access': 'production',
-        'id': 991122,
-        'secrets': ['aws_deployments']
+    "control": {
+        "description": "AWS Master Environment",
+        "type": "aws",
+        "access": "production",
+        "id": 991122,
+        "secrets": ["aws_deployments"],
     },
 }
 
 
 SECRETS = {
-    'aws_deployments':
-    {
-        'key': 'km_managed_api_user',
-        'provider': 'IAM',
-        'rotate': 'nightly',
-        'distribute': [
+    "aws_deployments": {
+        "key": "km_managed_api_user",
+        "provider": "IAM",
+        "rotate": "nightly",
+        "distribute": [
             {
-                'key': 'KM_{ENV}_AWS_ACCESS_ID',
-                'provider': 'bitbucket',
-                'source': 'key',
-                'envs': [
-                  '*'
-                ],
-                'config': {
-                    'scope': 'account'
-                }
+                "key": "KM_{ENV}_AWS_ACCESS_ID",
+                "provider": "bitbucket",
+                "source": "key",
+                "envs": ["*"],
+                "config": {"scope": "account"},
             },
             {
-                'key': 'KM_{ENV}_AWS_SECRET_ACCESS_KEY',
-                'provider': 'bitbucket',
-                'source': 'secret',
-                'envs': [
-                    '*'
-                ],
-                'config': {
-                    'scope': 'account'
-                }
+                "key": "KM_{ENV}_AWS_SECRET_ACCESS_KEY",
+                "provider": "bitbucket",
+                "source": "secret",
+                "envs": ["*"],
+                "config": {"scope": "account"},
             },
             {
-                'key': 'KM_MANAGED_AWS_ACCESS_ID',
-                'provider': 'bitbucket',
-                'source': 'key',
-                'envs': [
-                    'dev'
-                ],
-                'config': {
-                    'scope': 'account'
-                }
+                "key": "KM_MANAGED_AWS_ACCESS_ID",
+                "provider": "bitbucket",
+                "source": "key",
+                "envs": ["dev"],
+                "config": {"scope": "account"},
             },
             {
-                'key': 'KM_MANAGED_AWS_SECRET_ACCESS_KEY',
-                'provider': 'bitbucket',
-                'source': 'secret',
-                'envs': [
-                    'dev'
-                ],
-                'config': {
-                    'scope': 'account'
-                }
-            }
-        ]
+                "key": "KM_MANAGED_AWS_SECRET_ACCESS_KEY",
+                "provider": "bitbucket",
+                "source": "secret",
+                "envs": ["dev"],
+                "config": {"scope": "account"},
+            },
+        ],
     },
-    'aws_deployment_just_rotate':
-    {
-        'key': 'km_managed_just_rotate',
-        'provider': 'IAM',
-        'rotate': 'nightly'
+    "aws_deployment_just_rotate": {
+        "key": "km_managed_just_rotate",
+        "provider": "IAM",
+        "rotate": "nightly",
     },
-    'splunk':
-    {
-        'key': 'splunk',
-        'provider': 'salesforce',
-        'rotate': 'monthly'
+    "splunk": {"key": "splunk", "provider": "salesforce", "rotate": "monthly"},
+    "cloudflare_canary": {
+        "key": "cloudflare_canary_key",
+        "provider": "cloudflare",
+        "rotate": "canaries",
     },
-    'cloudflare_canary':
-    {
-        'key': 'cloudflare_canary_key',
-        'provider': 'cloudflare',
-        'rotate': 'canaries'
+    "okta_canary": {"key": "okta_canary_key", "provider": "okta", "rotate": "canaries"},
+    "office365_adhoc": {
+        "key": "control_secrets",
+        "provider": "office365",
+        "rotate": "adhoc",
     },
-    'okta_canary':
-    {
-        'key': 'okta_canary_key',
-        'provider': 'okta',
-        'rotate': 'canaries'
-    },
-    'office365_adhoc':
-    {
-        'key': 'control_secrets',
-        'provider': 'office365',
-        'rotate': 'adhoc'
-    }
 }
 
 
 SECRETS_S = {
-    'splunk':
-    {
-        'key': 'splunk',
-        'provider': 'salesforce',
-        'rotate': 'monthly',
-        'distribute': [{'provider': 'secretsmanager', 'envs': ['dev']}]
+    "splunk": {
+        "key": "splunk",
+        "provider": "salesforce",
+        "rotate": "monthly",
+        "distribute": [{"provider": "secretsmanager", "envs": ["dev"]}],
     }
 }
 
 
 ENV_CONFIG = {
-    'provider': 'bitbucket',
-    'config': {
-        'account_username': 'acct_user',
-        'secrets': {
-            'repository': 'secrets_repo',
-            'path': 'secrets_path',
-            'filetype': 'secrets_filetype'
+    "provider": "bitbucket",
+    "config": {
+        "account_username": "acct_user",
+        "secrets": {
+            "repository": "secrets_repo",
+            "path": "secrets_path",
+            "filetype": "secrets_filetype",
         },
-        'environments': {
-            'repository': 'envs_repo',
-            'path': 'envs_path',
-            'filetype': 'envs_filetype'
-        }
-    }
+        "environments": {
+            "repository": "envs_repo",
+            "path": "envs_path",
+            "filetype": "envs_filetype",
+        },
+    },
 }
 
 
 class TestConfig(unittest.TestCase):
     def setUp(self):
         self.session = MagicMock()
-        self.client = KeydraConfig(
-            session=self.session,
-            config=ENV_CONFIG
-        )
+        self.client = KeydraConfig(session=self.session, config=ENV_CONFIG)
 
     def test__dodgy_config(self):
         with self.assertRaises(ConfigException):
-            KeydraConfig(
-                session=MagicMock(),
-                config={}
-            )
+            KeydraConfig(session=MagicMock(), config={})
 
         with self.assertRaises(ConfigException):
-            KeydraConfig(
-                session=MagicMock(),
-                config={'provider': {}}
-            )
+            KeydraConfig(session=MagicMock(), config={"provider": {}})
 
     def test__validate_spec_environments(self):
         envs = copy.deepcopy(ENVS)
@@ -190,14 +150,14 @@ class TestConfig(unittest.TestCase):
 
         self.client._validate_spec(envs, secrets)
 
-        envs['prod'].pop('type')
+        envs["prod"].pop("type")
 
         with self.assertRaises(ConfigException):
             self.client._validate_spec(envs, secrets)
 
         envs = copy.deepcopy(ENVS)
 
-        envs['prod'].pop('id')
+        envs["prod"].pop("id")
 
         with self.assertRaises(ConfigException):
             self.client._validate_spec(envs, secrets)
@@ -205,7 +165,7 @@ class TestConfig(unittest.TestCase):
         with self.assertRaises(ConfigException):
             secrets = copy.deepcopy(SECRETS)
 
-            secrets['aws_deployments']['distribute'][0]['envs'] = ['notanenv']
+            secrets["aws_deployments"]["distribute"][0]["envs"] = ["notanenv"]
             self.client._validate_spec(ENVS, secrets)
 
     def test__validate_spec_secrets(self):
@@ -214,133 +174,121 @@ class TestConfig(unittest.TestCase):
 
         self.client._validate_spec(envs, secrets)
 
-        secrets['aws_deployments'].pop('provider')
+        secrets["aws_deployments"].pop("provider")
 
         with self.assertRaises(ConfigException):
             self.client._validate_spec(envs, secrets)
 
         secrets = copy.deepcopy(SECRETS)
 
-        secrets['aws_deployments'].pop('key')
+        secrets["aws_deployments"].pop("key")
 
         with self.assertRaises(ConfigException):
             self.client._validate_spec(envs, secrets)
 
         secrets = copy.deepcopy(SECRETS)
 
-        secrets['aws_deployments']['distribute'][0].pop('provider')
+        secrets["aws_deployments"]["distribute"][0].pop("provider")
 
         with self.assertRaises(ConfigException):
             self.client._validate_spec(envs, secrets)
 
     def test__guess_current_environment(self):
-        with patch.object(self.client, '_fetch_current_account') as mk_fca:
+        with patch.object(self.client, "_fetch_current_account") as mk_fca:
             mk_fca.return_value = 334455
-            self.assertEquals(
-                self.client._guess_current_environment(ENVS), 'uat'
-            )
+            self.assertEquals(self.client._guess_current_environment(ENVS), "uat")
 
             mk_fca.return_value = 667788
-            self.assertEquals(
-                self.client._guess_current_environment(ENVS), 'prod'
-            )
+            self.assertEquals(self.client._guess_current_environment(ENVS), "prod")
 
             mk_fca.return_value = 999999
             with self.assertRaises(ConfigException):
                 self.client._guess_current_environment(ENVS)
 
     def test__filter(self):
-        with patch.object(
-            self.client, '_guess_current_environment'
-        ) as mk_gce:
+        with patch.object(self.client, "_guess_current_environment") as mk_gce:
 
-            mk_gce.return_value = 'prod'
-            filtered = self.client._filter(ENVS, SECRETS, rotate='nightly')
+            mk_gce.return_value = "prod"
+            filtered = self.client._filter(ENVS, SECRETS, rotate="nightly")
             self.assertEqual(len(filtered), 1)
-            self.assertEqual(len(filtered[0]['distribute']), 2)
+            self.assertEqual(len(filtered[0]["distribute"]), 2)
 
-            mk_gce.return_value = 'dev'
-            filtered = self.client._filter(ENVS, SECRETS, rotate='nightly')
+            mk_gce.return_value = "dev"
+            filtered = self.client._filter(ENVS, SECRETS, rotate="nightly")
             self.assertEqual(len(filtered), 2)
-            self.assertEqual(filtered[0]['key'], 'km_managed_api_user')
-            self.assertEqual(len(filtered[0]['distribute']), 4)
+            self.assertEqual(filtered[0]["key"], "km_managed_api_user")
+            self.assertEqual(len(filtered[0]["distribute"]), 4)
 
-            mk_gce.return_value = 'dev'
+            mk_gce.return_value = "dev"
             filtered = self.client._filter(
-                ENVS, SECRETS, requested_secrets=[], rotate='nightly'
+                ENVS, SECRETS, requested_secrets=[], rotate="nightly"
             )
             self.assertEqual(len(filtered), 2)
-            self.assertEqual(filtered[0]['key'], 'km_managed_api_user')
-            self.assertEqual(len(filtered[0]['distribute']), 4)
+            self.assertEqual(filtered[0]["key"], "km_managed_api_user")
+            self.assertEqual(len(filtered[0]["distribute"]), 4)
 
-            mk_gce.return_value = 'dev'
+            mk_gce.return_value = "dev"
             filtered = self.client._filter(
                 ENVS,
                 SECRETS,
-                requested_secrets=['aws_deployment_just_rotate'],
-                rotate='nightly'
+                requested_secrets=["aws_deployment_just_rotate"],
+                rotate="nightly",
             )
             self.assertEqual(len(filtered), 1)
-            self.assertEqual(filtered[0]['key'], 'km_managed_just_rotate')
+            self.assertEqual(filtered[0]["key"], "km_managed_just_rotate")
 
-            mk_gce.return_value = 'dev'
-            filtered = self.client._filter(ENVS, SECRETS, rotate='monthly')
+            mk_gce.return_value = "dev"
+            filtered = self.client._filter(ENVS, SECRETS, rotate="monthly")
             self.assertEqual(len(filtered), 1)
-            self.assertEqual(filtered[0]['key'], 'splunk')
+            self.assertEqual(filtered[0]["key"], "splunk")
 
-            mk_gce.return_value = 'dev'
-            filtered = self.client._filter(ENVS, SECRETS_S, rotate='monthly')
+            mk_gce.return_value = "dev"
+            filtered = self.client._filter(ENVS, SECRETS_S, rotate="monthly")
             self.assertEqual(len(filtered), 1)
-            self.assertEqual(filtered[0]['key'], 'splunk')
-            self.assertEqual(
-                filtered[0]['distribute'][0]['provider'], 'secretsmanager'
-            )
+            self.assertEqual(filtered[0]["key"], "splunk")
+            self.assertEqual(filtered[0]["distribute"][0]["provider"], "secretsmanager")
 
-            mk_gce.return_value = 'dev'
+            mk_gce.return_value = "dev"
             filtered = self.client._filter(
-                ENVS, SECRETS_S, rotate='adhoc', requested_secrets=['splunk']
+                ENVS, SECRETS_S, rotate="adhoc", requested_secrets=["splunk"]
             )
             self.assertEqual(len(filtered), 1)
-            self.assertEqual(filtered[0]['key'], 'splunk')
-            self.assertEqual(
-                filtered[0]['distribute'][0]['provider'], 'secretsmanager'
-            )
+            self.assertEqual(filtered[0]["key"], "splunk")
+            self.assertEqual(filtered[0]["distribute"][0]["provider"], "secretsmanager")
 
-            mk_gce.return_value = 'dev'
-            filtered = self.client._filter(ENVS, SECRETS, rotate='canaries')
+            mk_gce.return_value = "dev"
+            filtered = self.client._filter(ENVS, SECRETS, rotate="canaries")
             self.assertEqual(len(filtered), 2)
-            self.assertEqual(filtered[0]['key'], 'cloudflare_canary_key')
-            self.assertEqual(filtered[1]['key'], 'okta_canary_key')
+            self.assertEqual(filtered[0]["key"], "cloudflare_canary_key")
+            self.assertEqual(filtered[1]["key"], "okta_canary_key")
 
-    @patch('keydra.loader.build_client')
+    @patch("keydra.loader.build_client")
     def test_load_secret_specs(self, mk_bc):
-        with patch.object(self.client, '_filter') as mk_fba:
-            with patch.object(self.client, '_validate_spec') as mk_vc:
+        with patch.object(self.client, "_filter") as mk_fba:
+            with patch.object(self.client, "_validate_spec") as mk_vc:
                 self.client.load_secrets()
 
-                mk_bc.assert_called_once_with(ENV_CONFIG['provider'], None)
+                mk_bc.assert_called_once_with(ENV_CONFIG["provider"], None)
                 mk_fba.assert_called()
                 mk_vc.assert_called()
 
     def test__filter_no_batch_size(self):
         all_secrets = {}
-        envs = {'dev': {'secrets': []}}
+        envs = {"dev": {"secrets": []}}
 
         for i in range(1, 11):
-            secret_id = 'secret' + str(i)
+            secret_id = "secret" + str(i)
             all_secrets[secret_id] = {
-                'key': 'km_secret',
-                'provider': 'IAM',
-                'rotate': 'nightly'
+                "key": "km_secret",
+                "provider": "IAM",
+                "rotate": "nightly",
             }
-            envs['dev']['secrets'].append(str(secret_id))
+            envs["dev"]["secrets"].append(str(secret_id))
 
-        with patch.object(
-            self.client, '_guess_current_environment'
-        ) as mk_gce:
-            mk_gce.return_value = 'dev'
+        with patch.object(self.client, "_guess_current_environment") as mk_gce:
+            mk_gce.return_value = "dev"
 
-            filtered_secrets = self.client._filter(envs, all_secrets, rotate='nightly')
+            filtered_secrets = self.client._filter(envs, all_secrets, rotate="nightly")
 
             assert len(filtered_secrets) == len(all_secrets)
 
@@ -348,7 +296,10 @@ class TestConfig(unittest.TestCase):
         # test parameters are number of batches, batch number
         batch_paramters = [
             (0, 0),  # zero batches
-            (2, 2),  # 2 batches, trying to fetch batch number 2, batch number starts at 0
+            (
+                2,
+                2,
+            ),  # 2 batches, trying to fetch batch number 2, batch number starts at 0
             (2, 4),  # 2 batches, trying to fetch a batch number that is out pf range
             (1, -1),  # negative batch number
             (-1, 1),  # negative number of batches
@@ -358,59 +309,83 @@ class TestConfig(unittest.TestCase):
             ("str", "str2"),  # double string
         ]
         for (number_of_batches, batch_number) in batch_paramters:
-            with self.subTest(f'testing failure for number of batches {number_of_batches}, batch number {batch_number}'):
+            with self.subTest(
+                f"testing failure for number of batches {number_of_batches}, batch number {batch_number}"
+            ):
                 all_secrets = {}
-                envs = {'dev': {'secrets': []}}
+                envs = {"dev": {"secrets": []}}
 
                 for i in range(1, 10):
-                    secret_id = 'secret' + str(i)
+                    secret_id = "secret" + str(i)
                     all_secrets[secret_id] = {
-                        'key': secret_id,
-                        'provider': 'IAM',
-                        'rotate': 'nightly'
+                        "key": secret_id,
+                        "provider": "IAM",
+                        "rotate": "nightly",
                     }
-                    all_secrets[secret_id][secret_id] = 'for assertion'
-                    envs['dev']['secrets'].append(str(secret_id))
+                    all_secrets[secret_id][secret_id] = "for assertion"
+                    envs["dev"]["secrets"].append(str(secret_id))
 
-                with patch.object(
-                        self.client, '_guess_current_environment'
-                ) as mk_gce:
-                    mk_gce.return_value = 'dev'
-                    with self.assertRaises(Exception) as context:
-                        filtered_secrets = self.client._filter(
-                            envs, all_secrets, rotate='nightly', batch_number=batch_number, number_of_batches=number_of_batches)
+                with patch.object(self.client, "_guess_current_environment") as mk_gce:
+                    mk_gce.return_value = "dev"
+                    with self.assertRaises(Exception):
+                        self.client._filter(
+                            envs,
+                            all_secrets,
+                            rotate="nightly",
+                            batch_number=batch_number,
+                            number_of_batches=number_of_batches,
+                        )
 
     def test_batch_runs(self):
-        # test parameters are number of secrets, number of batches, batch number, expected number of filtered secrets, secret in first element
+        """
+        test parameters in list
+        number of secrets,
+        number of batches,
+        batch number,
+        expected number of filtered secrets,
+        secret in first element
+        :return:
+        """
         batch_paramters = [
-            (5, 1, 0, 5, 'secret1'),  # single batch
-            (4, 2, 0, 2, 'secret1'),  # 2 batches, even number of secrets
-            (5, 2, 1, 2, 'secret4'),  # 2 batches, odd number of secrets
-            (10, 3, 1, 4, 'secret5'),  # 3 batches, get middle batch
-            (10, 3, 0, 4, 'secret1'),  # 3 batches, get first batch
-            (10, 3, 2, 2, 'secret9'),  # 3 batches, get last batch
+            (5, 1, 0, 5, "secret1"),  # single batch
+            (4, 2, 0, 2, "secret1"),  # 2 batches, even number of secrets
+            (5, 2, 1, 2, "secret4"),  # 2 batches, odd number of secrets
+            (10, 3, 1, 4, "secret5"),  # 3 batches, get middle batch
+            (10, 3, 0, 4, "secret1"),  # 3 batches, get first batch
+            (10, 3, 2, 2, "secret9"),  # 3 batches, get last batch
         ]
-        for (number_of_secrets, number_of_batches, batch_number, filtered_secrets_len, expected_first_secret) in batch_paramters:
-            with self.subTest(f'testing for {number_of_secrets} secrets, number of batches {number_of_batches}, batch number {batch_number}'):
+        for (
+            number_of_secrets,
+            number_of_batches,
+            batch_number,
+            filtered_secrets_len,
+            expected_first_secret,
+        ) in batch_paramters:
+            with self.subTest(
+                f"testing for {number_of_secrets} secrets, batch number {batch_number} of {number_of_batches}"
+            ):
                 all_secrets = {}
-                envs = {'dev': {'secrets': []}}
+                envs = {"dev": {"secrets": []}}
 
-                for i in range(1, number_of_secrets+1):
-                    secret_id = 'secret' + str(i)
+                for i in range(1, number_of_secrets + 1):
+                    secret_id = "secret" + str(i)
                     all_secrets[secret_id] = {
-                        'key': secret_id,
-                        'provider': 'IAM',
-                        'rotate': 'nightly'
+                        "key": secret_id,
+                        "provider": "IAM",
+                        "rotate": "nightly",
                     }
-                    all_secrets[secret_id][secret_id] = 'for assertion'
-                    envs['dev']['secrets'].append(str(secret_id))
+                    all_secrets[secret_id][secret_id] = "for assertion"
+                    envs["dev"]["secrets"].append(str(secret_id))
 
-                with patch.object(
-                        self.client, '_guess_current_environment'
-                ) as mk_gce:
-                    mk_gce.return_value = 'dev'
+                with patch.object(self.client, "_guess_current_environment") as mk_gce:
+                    mk_gce.return_value = "dev"
                     filtered_secrets = self.client._filter(
-                        envs, all_secrets, rotate='nightly', batch_number=batch_number, number_of_batches=number_of_batches)
+                        envs,
+                        all_secrets,
+                        rotate="nightly",
+                        batch_number=batch_number,
+                        number_of_batches=number_of_batches,
+                    )
                     # should be a 3 - 2 split so batch number 0 should have 3 and number 1 should have 2
                     assert len(filtered_secrets) == filtered_secrets_len
                     assert expected_first_secret in filtered_secrets[0]

--- a/tests/test_keydra.py
+++ b/tests/test_keydra.py
@@ -175,7 +175,7 @@ class TestKeydra(unittest.TestCase):
         self.assertEqual(result[0]['rotate_secret']['status'], 'success')
         self.assertEqual(result[0]['distribute_secret']['status'], 'success')
         self._cfg.load_secrets.assert_called_once_with(
-            secrets=CONFIG, rotate='nightly')
+            secrets=CONFIG, rotate='nightly', batch_number=None, number_of_batches=None)
 
     def test__distribute_secret_failure(self):
         result = self._kdra._distribute_secret({


### PR DESCRIPTION
Replacing the old secondary keydra nightly rotation option with a batch number and number of batches configuration.  
Previously the secondary keydra rotation option had a hard-coded run of the first 50 secrets then the rest.  
This new option will allow you to specify the number of batches you want to split the rotation into and which batch to process, batch number starts from 0.

e.g. for keydra you can specify
{"trigger": "nightly", batch_number: 0, number_of_batches: 2}
this will split the secrets into 2 batches and run the first batch of secrets