### PR TITLE
Adding Semgrep to workflow actions

### DIFF
--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -1,0 +1,49 @@
+# Name of this GitHub Actions workflow.
+name: Security
+
+on:
+  # Scan changed files in PRs (diff-aware scanning):
+  pull_request: {}
+  # Scan mainline branches and report all findings: 
+  push:
+    branches: ["main"]
+  # Schedule the CI job (this method uses cron syntax):
+  schedule:
+    - cron: '30 0 1,15 * *' # Scheduled for 00:30 UTC on both the 1st and 15th of the month
+
+jobs:
+  semgrep:
+    # User-definable name of this GitHub Actions job:
+    name: Semgrep SAST Scan
+    runs-on: ubuntu-latest
+
+    container:
+      # A Docker image with Semgrep installed. Do not change this.
+      image: returntocorp/semgrep
+
+    # Skip any PR created by dependabot to avoid permission issues:
+    if: (github.actor != 'dependabot[bot]')
+
+    steps:
+      # Fetch project source with GitHub Actions Checkout.
+      - uses: actions/checkout@v3
+
+      # Run the "semgrep ci" command on the command line of the docker image.
+      - name: Run Semgrep for Security Rulesets
+        run: semgrep ci --sarif --output semgrep-results.sarif
+        env:
+           # Add the rules that Semgrep uses by setting the SEMGREP_RULES environment variable. 
+           SEMGREP_RULES: p/owasp-top-ten p/security-audit
+
+           # Uncomment SEMGREP_TIMEOUT to set this job's timeout (in seconds):
+           # Default timeout is 1800 seconds (30 minutes).
+           # Set to 0 to disable the timeout.
+           # SEMGREP_TIMEOUT: 300
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: semgrep-results.sarif
+          category: semgrep
+        if: always()
+


### PR DESCRIPTION
Adding some light SAST security scanning to workflows (using semgrep). This will provide some basic protection against  dangerous code being introduced. The findings will appear in the security code scanning view for repo admins, won't be visible for plebs like me, but should prove useful.