### PR TITLE
Feature/Redact secrets

### DIFF
--- a/src/keydra/keydra.py
+++ b/src/keydra/keydra.py
@@ -1,11 +1,10 @@
 from botocore.exceptions import ClientError
+
 from keydra import loader
-
 from keydra import logging as km_logging
-from keydra.config import KeydraConfig
-
-from keydra.exceptions import ConfigException, InvalidSecretProvider
 from keydra.clients.aws.cloudwatch import CloudwatchClient, timed
+from keydra.config import KeydraConfig
+from keydra.exceptions import ConfigException, InvalidSecretProvider
 
 LOGGER = km_logging.get_logger()
 
@@ -182,7 +181,8 @@ class Keydra(object):
             )
             return self._fail(e)
 
-    def _default_response(self, status, action=None, msg=None, value=None):
+    @staticmethod
+    def _default_response(status, action=None, msg=None, value=None):
         response = {
             'status': status,
         }
@@ -198,19 +198,17 @@ class Keydra(object):
 
         return response
 
-    def _fail(self, msg, action=None, value=None):
-        return self._default_response('fail',
-                                      action=action,
-                                      msg=str(msg),
-                                      value=value)
+    @staticmethod
+    def _fail(msg, action=None, value=None):
+        return Keydra._default_response('fail', action=action, value=value, msg=str(msg), )
 
-    def _success(self, value, action=None):
-        return self._default_response('success', action=action, value=value)
+    @staticmethod
+    def _success(value, action=None):
+        return Keydra._default_response('success', action=action, value=value)
 
-    def _partial_success(self, value, msg, action=None):
-        return self._default_response(
-            'partial_success', action=action, value=value, msg=msg
-        )
+    @staticmethod
+    def _partial_success(value, msg, action=None):
+        return Keydra._default_response('partial_success', action=action, value=value, msg=msg)
 
     # TODO: abstract these metrics functions to a class
     def _emit_spec_metrics(self, secrets):
@@ -264,8 +262,7 @@ class Keydra(object):
             elif result['rotate_secret']['status'] == 'fail':
                 failed_rotations += 1
 
-            for dresult in \
-                    result.get('distribute_secret', {}).get('value', []):
+            for dresult in result.get('distribute_secret', {}).get('value', []):
                 if dresult['status'] == 'success':
                     successful_distributions += 1
 

--- a/src/keydra/keydra.py
+++ b/src/keydra/keydra.py
@@ -66,8 +66,7 @@ class Keydra(object):
             result['key'] = secret['key']
             result['provider'] = secret['provider']
 
-            result[r_result.pop('action')] = self._redact_secrets(
-                r_result, secret)
+            result[r_result.pop('action')] = self._redact_secrets(r_result, secret)
 
             if r_result['status'] == 'success' and 'distribute' in secret:
                 d_result = self._distribute_secret(secret, r_result['value'])
@@ -80,24 +79,15 @@ class Keydra(object):
 
         return resp
 
-    def _redact_secrets(self, result: dict, spec: dict):
+    @staticmethod
+    def _redact_secrets(result: dict, spec: dict):
         r_result = copy.deepcopy(result)
         provider = spec['provider']
 
-        LOGGER.debug(
-            'Redacting the value of {}::{}'.format(
-                spec['provider'],
-                spec['key']))
+        LOGGER.debug('Redacting the value of {}::{}'.format(spec['provider'], spec['key']))
 
-        try:
-            km_provider = loader.load_provider_client(provider)
-
-            return km_provider.redact_result(r_result, spec)
-
-        except InvalidSecretProvider:
-            pass
-
-        return r_result
+        km_provider = loader.load_provider_client(provider)
+        return km_provider.redact_result(r_result, spec)
 
     @timed('rotation', specialise=True)
     def _rotate_secret(self, secret):

--- a/src/keydra/keydra.py
+++ b/src/keydra/keydra.py
@@ -10,7 +10,7 @@ LOGGER = km_logging.get_logger()
 
 
 class Keydra(object):
-    def __init__(self, cfg: KeydraConfig, cw: CloudwatchClient, **kwargs):
+    def __init__(self, cfg: KeydraConfig, cw: CloudwatchClient):
         self._cfg = cfg
         self._cw = cw
 

--- a/src/keydra/keydra.py
+++ b/src/keydra/keydra.py
@@ -80,7 +80,7 @@ class Keydra(object):
 
         return resp
 
-    def _redact_secrets(self, result, spec):
+    def _redact_secrets(self, result: dict, spec: dict):
         r_result = copy.deepcopy(result)
         provider = spec['provider']
 

--- a/src/keydra/keydra.py
+++ b/src/keydra/keydra.py
@@ -1,5 +1,3 @@
-import copy
-
 from botocore.exceptions import ClientError
 from keydra import loader
 
@@ -81,13 +79,9 @@ class Keydra(object):
 
     @staticmethod
     def _redact_secrets(result: dict, spec: dict):
-        r_result = copy.deepcopy(result)
-        provider = spec['provider']
-
         LOGGER.debug('Redacting the value of {}::{}'.format(spec['provider'], spec['key']))
-
-        km_provider = loader.load_provider_client(provider)
-        return km_provider.redact_result(r_result, spec)
+        km_provider = loader.load_provider_client(spec['provider'])
+        return km_provider.redact_result(result, spec)
 
     @timed('rotation', specialise=True)
     def _rotate_secret(self, secret):

--- a/src/keydra/keydra.py
+++ b/src/keydra/keydra.py
@@ -18,7 +18,11 @@ class Keydra(object):
     def rotate_and_distribute(self, run_for_secrets, rotate, batch_number=None, number_of_batches=None):
         try:
             secrets = self._cfg.load_secrets(
-                secrets=run_for_secrets, rotate=rotate, batch_number=batch_number, number_of_batches=number_of_batches)
+                secrets=run_for_secrets,
+                rotate=rotate,
+                batch_number=batch_number,
+                number_of_batches=number_of_batches
+            )
         except ConfigException as e:
             LOGGER.error(e)
             return [self._fail(e)]
@@ -38,7 +42,7 @@ class Keydra(object):
             }
         )
 
-        resp = []
+        response: [dict] = []
 
         for secret in secrets:
             result = {}
@@ -56,12 +60,12 @@ class Keydra(object):
                 d_result = self._distribute_secret(secret, r_result['value'])
                 result[d_result.pop('action')] = d_result
 
-            resp.append(result)
+            response.append(result)
 
         if rotate != 'adhoc':
-            self._emit_result_metrics(resp)
+            self._emit_result_metrics(response)
 
-        return resp
+        return response
 
     @staticmethod
     def _redact_secrets(result: dict, spec: dict):

--- a/src/keydra/keydra.py
+++ b/src/keydra/keydra.py
@@ -16,20 +16,6 @@ class Keydra(object):
         self._cw = cw
 
     def rotate_and_distribute(self, run_for_secrets, rotate, batch_number=None, number_of_batches=None):
-        '''
-        AWS Lambda handler
-
-        :param event: Event triggering this function
-        :type event: :class:`dict`
-        :param context: Lambda Context runtime methods and attributes
-        :type context: :class:`object`
-
-        `context` attributes
-        ------------------
-        '''
-
-        secrets = None
-
         try:
             secrets = self._cfg.load_secrets(
                 secrets=run_for_secrets, rotate=rotate, batch_number=batch_number, number_of_batches=number_of_batches)

--- a/src/keydra/loader.py
+++ b/src/keydra/loader.py
@@ -44,8 +44,6 @@ LOGGER = km_logging.get_logger()
 
 
 def fetch_provider_creds(provider, key_name):
-    secret_value = None
-
     secret_id = '{}/{}'.format(KEYDRA_SECRETS_PREFIX, provider.lower())
 
     if key_name:
@@ -55,19 +53,15 @@ def fetch_provider_creds(provider, key_name):
         LOGGER.debug('Loading {} from Secrets Manager'.format(secret_id))
         secret_value = SECRETS_MANAGER.get_secret_value(secret_id)
     except ClientError as e:  # pragma: no cover
-        LOGGER.debug(
-            'Not able to read credentials for: {} -- {}'.format(provider, e))
-        raise ConfigException(
-            'Failed to read {} from Secrets Manager: {}'.format(
-                secret_id, e))
+        LOGGER.debug('Not able to read credentials for: {} -- {}'.format(provider, e))
+        raise ConfigException('Failed to read {} from Secrets Manager: {}'.format(secret_id, e))
 
     try:
         LOGGER.debug('Attempting to convert secret to JSON')
         return json.loads(secret_value)
     except Exception as e:
         LOGGER.debug('Failed converting {} to JSON: {}'.format(secret_id, e))
-        raise ConfigException(
-            'The value of {} is not valid JSON'.format(secret_id))
+        raise ConfigException('The value of {} is not valid JSON'.format(secret_id))
 
 
 def load_provider_client(secret_provider: str):

--- a/src/keydra/loader.py
+++ b/src/keydra/loader.py
@@ -70,7 +70,7 @@ def fetch_provider_creds(provider, key_name):
             'The value of {} is not valid JSON'.format(secret_id))
 
 
-def load_provider_client(secret_provider):
+def load_provider_client(secret_provider: str):
     try:
         sanitized_provider = secret_provider.lower()
         module_name = 'keydra.providers.{}'.format(

--- a/src/keydra/providers/aws_appsync.py
+++ b/src/keydra/providers/aws_appsync.py
@@ -126,11 +126,8 @@ class Client(BaseProvider):
                 return False, 'Please provide a config specifying the api-id'
 
     @classmethod
-    def redact_result(cls, result, spec=None):
-        if 'value' in result and 'secret' in result['value']:
-            result['value']['secret'] = '***'
-
-        return result
+    def safe_to_log_keys(cls, spec) -> [str]:
+        return ['provider', 'key']
 
     @classmethod
     def has_creds(cls):

--- a/src/keydra/providers/aws_appsync.py
+++ b/src/keydra/providers/aws_appsync.py
@@ -126,9 +126,5 @@ class Client(BaseProvider):
                 return False, 'Please provide a config specifying the api-id'
 
     @classmethod
-    def safe_to_log_keys(cls, spec) -> [str]:
-        return ['provider', 'key']
-
-    @classmethod
     def has_creds(cls):
         return False

--- a/src/keydra/providers/aws_iam.py
+++ b/src/keydra/providers/aws_iam.py
@@ -333,11 +333,8 @@ class Client(BaseProvider):
         raise DistributionException('IAM does not support distribution')
 
     @classmethod
-    def redact_result(cls, result, spec=None):
-        if 'value' in result and PW_FIELD in result['value']:
-            result['value'][PW_FIELD] = '***'
-
-        return result
+    def safe_to_log_keys(cls, spec) -> [str]:
+        return ['provider', 'key']
 
     @classmethod
     def validate_spec(cls, spec):

--- a/src/keydra/providers/aws_iam.py
+++ b/src/keydra/providers/aws_iam.py
@@ -333,10 +333,6 @@ class Client(BaseProvider):
         raise DistributionException('IAM does not support distribution')
 
     @classmethod
-    def safe_to_log_keys(cls, spec) -> [str]:
-        return ['provider', 'key']
-
-    @classmethod
     def validate_spec(cls, spec):
         valid, msg = BaseProvider.validate_spec(spec)
         if not valid:

--- a/src/keydra/providers/aws_secretsmanager.py
+++ b/src/keydra/providers/aws_secretsmanager.py
@@ -181,7 +181,7 @@ class SecretsManagerProvider(BaseProvider):
         return True, 'All good!'
 
     @classmethod
-    def redact_result(cls, result, spec=None):
+    def redact_result(cls, result: dict, spec: dict) -> dict:
         if 'value' in result:
             for key, value in result['value'].items():
                 if key != 'provider':

--- a/src/keydra/providers/aws_secretsmanager.py
+++ b/src/keydra/providers/aws_secretsmanager.py
@@ -181,13 +181,8 @@ class SecretsManagerProvider(BaseProvider):
         return True, 'All good!'
 
     @classmethod
-    def redact_result(cls, result: dict, spec: dict) -> dict:
-        if 'value' in result:
-            for key, value in result['value'].items():
-                if key != 'provider':
-                    result['value'][key] = '***'
-
-        return result
+    def safe_to_log_keys(cls, spec) -> [str]:
+        return ['provider']  # call to superclass intentionally skipped
 
     @classmethod
     def has_creds(cls):

--- a/src/keydra/providers/aws_ssmparameterstore.py
+++ b/src/keydra/providers/aws_ssmparameterstore.py
@@ -168,13 +168,8 @@ class SSMParameterProvider(BaseProvider):
         return True, 'All good!'
 
     @classmethod
-    def redact_result(cls, result: dict, spec: dict) -> dict:
-        if 'value' in result:
-            for key, value in result['value'].items():
-                if key != 'provider':
-                    result['value'][key] = '***'
-
-        return result
+    def safe_to_log_keys(cls, spec) -> [str]:
+        return ['provider']  # call to superclass intentionally skipped
 
     @classmethod
     def has_creds(cls):

--- a/src/keydra/providers/aws_ssmparameterstore.py
+++ b/src/keydra/providers/aws_ssmparameterstore.py
@@ -168,7 +168,7 @@ class SSMParameterProvider(BaseProvider):
         return True, 'All good!'
 
     @classmethod
-    def redact_result(cls, result, spec=None):
+    def redact_result(cls, result: dict, spec: dict) -> dict:
         if 'value' in result:
             for key, value in result['value'].items():
                 if key != 'provider':

--- a/src/keydra/providers/base.py
+++ b/src/keydra/providers/base.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import time
 import math
@@ -100,16 +101,17 @@ class BaseProvider(ABC):
 
     @classmethod
     def redact_result(cls, result: dict, spec: dict) -> dict:
+        redacted_result = copy.deepcopy(result)
         safe_keys = [key.lower() for key in cls.safe_to_log_keys(spec)]
 
         # If we got a result
-        if 'value' in result:
-            for key in list(result['value'].keys()):
+        if 'value' in redacted_result:
+            for key in list(redacted_result['value'].keys()):
                 # redact all values except for the approved ones
                 if key.lower() not in safe_keys:
-                    result['value'][key] = '***'
+                    redacted_result['value'][key] = '***'
 
-        return result
+        return redacted_result
 
     @classmethod
     def has_creds(cls):

--- a/src/keydra/providers/base.py
+++ b/src/keydra/providers/base.py
@@ -91,7 +91,24 @@ class BaseProvider(ABC):
         return True, 'All good!'
 
     @classmethod
-    def redact_result(self, result):
+    def safe_to_log_keys(cls, spec) -> [str]:
+        """
+        Extension point, override to define which keys within the result are safe to be logged.
+        Examples include "username", "endpoint", etc.
+        """
+        return []
+
+    @classmethod
+    def redact_result(cls, result, spec):
+        safe_keys = [key.lower() for key in cls.safe_to_log_keys(spec)]
+
+        # If we got a result
+        if 'value' in result:
+            for key in list(result['value'].keys()):
+                # redact all values except for the approved ones
+                if key.lower() not in safe_keys:
+                    result['value'][key] = '***'
+
         return result
 
     @classmethod

--- a/src/keydra/providers/base.py
+++ b/src/keydra/providers/base.py
@@ -99,7 +99,7 @@ class BaseProvider(ABC):
         return ['provider', 'key']
 
     @classmethod
-    def redact_result(cls, result, spec):
+    def redact_result(cls, result: dict, spec: dict) -> dict:
         safe_keys = [key.lower() for key in cls.safe_to_log_keys(spec)]
 
         # If we got a result

--- a/src/keydra/providers/base.py
+++ b/src/keydra/providers/base.py
@@ -96,7 +96,7 @@ class BaseProvider(ABC):
         Extension point, override to define which keys within the result are safe to be logged.
         Examples include "username", "endpoint", etc.
         """
-        return []
+        return ['provider', 'key']
 
     @classmethod
     def redact_result(cls, result, spec):

--- a/src/keydra/providers/cloudflare.py
+++ b/src/keydra/providers/cloudflare.py
@@ -90,7 +90,3 @@ class Client(BaseProvider):
         raise DistributionException(
             'Cloudflare provider does not support distribution'
         )
-
-    @classmethod
-    def safe_to_log_keys(cls, spec) -> [str]:
-        return ['provider']

--- a/src/keydra/providers/cloudflare.py
+++ b/src/keydra/providers/cloudflare.py
@@ -92,10 +92,5 @@ class Client(BaseProvider):
         )
 
     @classmethod
-    def redact_result(cls, result, spec=None):
-        if 'value' in result:
-            for key, value in result['value'].items():
-                if 'secret' in key:
-                    result['value'][key] = '***'
-
-        return result
+    def safe_to_log_keys(cls, spec) -> [str]:
+        return ['provider']

--- a/src/keydra/providers/contentful.py
+++ b/src/keydra/providers/contentful.py
@@ -78,8 +78,5 @@ class Client(BaseProvider):
         raise DistributionException('Contentful does not support distribution')
 
     @classmethod
-    def redact_result(cls, result, spec=None):
-        if 'value' in result and PW_FIELD in result['value']:
-            result['value'][PW_FIELD] = '***'
-
-        return result
+    def safe_to_log_keys(cls, spec) -> [str]:
+        return ['key', 'provider']

--- a/src/keydra/providers/contentful.py
+++ b/src/keydra/providers/contentful.py
@@ -76,7 +76,3 @@ class Client(BaseProvider):
 
     def distribute(self, secret, destination):
         raise DistributionException('Contentful does not support distribution')
-
-    @classmethod
-    def safe_to_log_keys(cls, spec) -> [str]:
-        return ['key', 'provider']

--- a/src/keydra/providers/qualys.py
+++ b/src/keydra/providers/qualys.py
@@ -122,8 +122,5 @@ class Client(BaseProvider):
         return True, 'It is valid!'     # pragma: no cover
 
     @classmethod
-    def redact_result(cls, result, spec=None):
-        if 'value' in result and PW_FIELD in result['value']:
-            result['value'][PW_FIELD] = '***'
-
-        return result
+    def safe_to_log_keys(cls, spec) -> [str]:
+        return [USER_FIELD, 'provider']

--- a/src/keydra/providers/qualys.py
+++ b/src/keydra/providers/qualys.py
@@ -123,4 +123,4 @@ class Client(BaseProvider):
 
     @classmethod
     def safe_to_log_keys(cls, spec) -> [str]:
-        return [USER_FIELD, 'provider']
+        return BaseProvider.safe_to_log_keys(spec) + [USER_FIELD]

--- a/src/keydra/providers/salesforce.py
+++ b/src/keydra/providers/salesforce.py
@@ -137,4 +137,4 @@ class Client(BaseProvider):
     @classmethod
     def safe_to_log_keys(cls, spec) -> [str]:
         opts = Client.Options(**spec.get('config', {}))
-        return [opts.user_field, opts.domain_field, 'provider']
+        return BaseProvider.safe_to_log_keys(spec) + [opts.user_field, opts.domain_field]

--- a/src/keydra/providers/salesforce.py
+++ b/src/keydra/providers/salesforce.py
@@ -135,12 +135,6 @@ class Client(BaseProvider):
         return True, 'It is valid!'
 
     @classmethod
-    def redact_result(cls, result, spec):
+    def safe_to_log_keys(cls, spec) -> [str]:
         opts = Client.Options(**spec.get('config', {}))
-
-        if 'value' in result:
-            for field in (opts.password_field, opts.token_field):
-                if field in result['value']:
-                    result['value'][field] = '***'
-
-        return result
+        return [opts.user_field, opts.domain_field, 'provider']

--- a/src/keydra/providers/salesforce_marketing_cloud.py
+++ b/src/keydra/providers/salesforce_marketing_cloud.py
@@ -134,4 +134,4 @@ class Client(BaseProvider):
     @classmethod
     def safe_to_log_keys(cls, spec) -> [str]:
         opts = Client.Options(**spec.get('config', {}))
-        return ['provider', opts.user_field]
+        return BaseProvider.safe_to_log_keys(spec) + [opts.user_field]

--- a/src/keydra/providers/salesforce_marketing_cloud.py
+++ b/src/keydra/providers/salesforce_marketing_cloud.py
@@ -132,14 +132,6 @@ class Client(BaseProvider):
         return True, 'It is valid!'
 
     @classmethod
-    def redact_result(cls, result, spec):
+    def safe_to_log_keys(cls, spec) -> [str]:
         opts = Client.Options(**spec.get('config', {}))
-
-        if 'value' in result:
-            for field in (
-                opts.password_field, opts.businessUnit_field, opts.mid_field, opts.subdomain_field
-            ):
-                if field in result['value']:
-                    result['value'][field] = '***'
-
-        return result
+        return ['provider', opts.user_field]

--- a/src/keydra/providers/splunk.py
+++ b/src/keydra/providers/splunk.py
@@ -253,8 +253,5 @@ class Client(BaseProvider):
         return True, 'It is valid!'
 
     @classmethod
-    def redact_result(cls, result, spec=None):
-        if 'value' in result and PW_FIELD in result['value']:
-            result['value'][PW_FIELD] = '***'
-
-        return result
+    def safe_to_log_keys(cls, spec) -> [str]:
+        return [USER_FIELD]

--- a/src/keydra/providers/splunk.py
+++ b/src/keydra/providers/splunk.py
@@ -254,4 +254,4 @@ class Client(BaseProvider):
 
     @classmethod
     def safe_to_log_keys(cls, spec) -> [str]:
-        return [USER_FIELD]
+        return BaseProvider.safe_to_log_keys(spec) + [USER_FIELD]

--- a/src/keydra/providers/splunk_hec.py
+++ b/src/keydra/providers/splunk_hec.py
@@ -145,8 +145,5 @@ class Client(BaseProvider):
         return True, 'It is valid!'
 
     @classmethod
-    def redact_result(cls, result, spec=None):
-        if 'value' in result and PW_FIELD in result['value']:
-            result['value'][PW_FIELD] = '***'
-
-        return result
+    def safe_to_log_keys(cls, spec) -> [str]:
+        return [USER_FIELD, SPLUNK_USER_FIELD, 'provider', 'key']

--- a/src/keydra/providers/splunk_hec.py
+++ b/src/keydra/providers/splunk_hec.py
@@ -146,4 +146,4 @@ class Client(BaseProvider):
 
     @classmethod
     def safe_to_log_keys(cls, spec) -> [str]:
-        return [USER_FIELD, SPLUNK_USER_FIELD, 'provider', 'key']
+        return BaseProvider.safe_to_log_keys(spec) + [USER_FIELD, SPLUNK_USER_FIELD]

--- a/tests/test_provider_aws_appsync.py
+++ b/tests/test_provider_aws_appsync.py
@@ -29,10 +29,11 @@ class TestProviderAWSAppSync(unittest.TestCase):
             }
         }
 
-        r_result = aws_appsync.Client.redact_result(result)
-        r_value = r_result['value']['secret']
+        r_result = aws_appsync.Client.redact_result(result, {})
 
-        self.assertNotEqual(r_value, 'THIS_IS_SECRET')
+        self.assertEqual(r_result['value']['provider'], 'appsync')
+        self.assertEqual(r_result['value']['key'], 'KEY_ID')
+        self.assertEqual(r_result['value']['secret'], '***')
 
     def test_validate_spec_valid(self):
         speci_valid = {

--- a/tests/test_provider_aws_iam.py
+++ b/tests/test_provider_aws_iam.py
@@ -38,7 +38,7 @@ class TestProviderAWSIAM(unittest.TestCase):
             }
         }
 
-        r_result = aws_iam.Client.redact_result(result)
+        r_result = aws_iam.Client.redact_result(result, {})
         r_value = r_result['value']['secret']
 
         self.assertNotEqual(r_value, 'THIS_IS_SECRET')

--- a/tests/test_provider_aws_secretsmanager.py
+++ b/tests/test_provider_aws_secretsmanager.py
@@ -262,7 +262,8 @@ class TestProviderAWSSecretsManager(unittest.TestCase):
             }
         }
 
-        r_result = SecretsManagerProvider.redact_result(result)
+        r_result = SecretsManagerProvider.redact_result(result, {})
+
         self.assertEqual(r_result, {
             'status': 'success',
             'action': 'rotate_secret',

--- a/tests/test_provider_aws_ssmparameterstore.py
+++ b/tests/test_provider_aws_ssmparameterstore.py
@@ -276,7 +276,8 @@ class TestProviderAWSSSMParameterStore(unittest.TestCase):
             }
         }
 
-        r_result = SSMParameterProvider.redact_result(result)
+        r_result = SSMParameterProvider.redact_result(result, {})
+
         self.assertEqual(r_result, {
             'status': 'success',
             'action': 'rotate_secret',

--- a/tests/test_provider_base.py
+++ b/tests/test_provider_base.py
@@ -69,7 +69,7 @@ class TestBaseProvider(unittest.TestCase):
 
         result = {'result': 'stuff'}
 
-        self.assertEqual(result, ProviderWithDefaultRedactImplementation().redact_result(result))
+        self.assertEqual(result, ProviderWithDefaultRedactImplementation().redact_result(result, {}))
 
     def test_redact_result_override(self):
         class ProviderThatRedactsResult(BaseProvider):
@@ -83,15 +83,15 @@ class TestBaseProvider(unittest.TestCase):
                 pass
 
             @classmethod
-            def redact_result(cls, result):
+            def redact_result(cls, result, spec):
                 result['result'] = '***'
 
                 return result
 
         result = {'result': 'stuff'}
-        r_result = ProviderThatRedactsResult().redact_result(result)
+        r_result = ProviderThatRedactsResult().redact_result(result, {})
 
-        self.assertNotEqual(r_result['result'], 'stuff')
+        self.assertEqual(r_result['result'], '***')
 
     def test_validate_spec_base(self):
         class DummyA(BaseProvider):

--- a/tests/test_provider_base.py
+++ b/tests/test_provider_base.py
@@ -71,28 +71,6 @@ class TestBaseProvider(unittest.TestCase):
 
         self.assertEqual(result, ProviderWithDefaultRedactImplementation().redact_result(result, {}))
 
-    def test_redact_result_override(self):
-        class ProviderThatRedactsResult(BaseProvider):
-            def load_config(self, config):
-                pass
-
-            def rotate(self, spec):
-                pass
-
-            def distribute(self, secret, dest):
-                pass
-
-            @classmethod
-            def redact_result(cls, result: dict, spec: dict) -> dict:
-                result['result'] = '***'
-
-                return result
-
-        result = {'result': 'stuff'}
-        r_result = ProviderThatRedactsResult().redact_result(result, {})
-
-        self.assertEqual(r_result['result'], '***')
-
     def test_validate_spec_base(self):
         class DummyA(BaseProvider):
             def rotate(self, spec):

--- a/tests/test_provider_base.py
+++ b/tests/test_provider_base.py
@@ -83,7 +83,7 @@ class TestBaseProvider(unittest.TestCase):
                 pass
 
             @classmethod
-            def redact_result(cls, result, spec):
+            def redact_result(cls, result: dict, spec: dict) -> dict:
                 result['result'] = '***'
 
                 return result

--- a/tests/test_provider_base.py
+++ b/tests/test_provider_base.py
@@ -66,6 +66,8 @@ class TestBaseProvider(unittest.TestCase):
                 'password': 'test-password',
             }
         }
+        redacted_result = BaseProvider.redact_result(original_result, {})
+        self.assertNotEqual(redacted_result, original_result)
         self.assertEqual({
             'some_key': 'some_value',
             'value': {
@@ -74,7 +76,7 @@ class TestBaseProvider(unittest.TestCase):
                 'secret': '***',
                 'password': '***',
             }
-        }, BaseProvider.redact_result(original_result, {}))
+        }, redacted_result)
 
     def test_validate_spec_base(self):
         class DummyA(BaseProvider):

--- a/tests/test_provider_base.py
+++ b/tests/test_provider_base.py
@@ -56,20 +56,25 @@ class TestBaseProvider(unittest.TestCase):
             datetime.now() - starttime, timedelta(seconds=0.1)
         )
 
-    def test_redact_result_no_override(self):
-        class ProviderWithDefaultRedactImplementation(BaseProvider):
-            def load_config(self, config):
-                pass
-
-            def rotate(self, spec):
-                pass
-
-            def distribute(self, secret, dest):
-                pass
-
-        result = {'result': 'stuff'}
-
-        self.assertEqual(result, ProviderWithDefaultRedactImplementation().redact_result(result, {}))
+    def test_redact_result_default_keys_get_redacted(self):
+        original_result = {
+            'some_key': 'some_value',
+            'value': {
+                'provider': 'test-provider',
+                'key': 'test-key',
+                'secret': 'test-secret',
+                'password': 'test-password',
+            }
+        }
+        self.assertEqual({
+            'some_key': 'some_value',
+            'value': {
+                'provider': 'test-provider',
+                'key': 'test-key',
+                'secret': '***',
+                'password': '***',
+            }
+        }, BaseProvider.redact_result(original_result, {}))
 
     def test_validate_spec_base(self):
         class DummyA(BaseProvider):

--- a/tests/test_provider_cloudflare.py
+++ b/tests/test_provider_cloudflare.py
@@ -187,8 +187,10 @@ class TestProviderCloudflare(unittest.TestCase):
             }
         }
 
-        r_result = cloudflare.Client.redact_result(result)
-        r_value = r_result['value']
+        r_result = cloudflare.Client.redact_result(result, {})
 
-        self.assertNotEqual(r_value['manage_tokens.secret'], 'SECRET_ONE')
-        self.assertNotEqual(r_value['manage_dns.secret'], 'SECRET_TWO')
+        self.assertEqual(r_result['value']['provider'], 'cloudflare')
+        self.assertEqual(r_result['value']['manage_dns.key'], '***')
+        self.assertEqual(r_result['value']['manage_dns.secret'], '***')
+        self.assertEqual(r_result['value']['manage_tokens.key'], '***')
+        self.assertEqual(r_result['value']['manage_tokens.secret'], '***')

--- a/tests/test_provider_contentful.py
+++ b/tests/test_provider_contentful.py
@@ -61,10 +61,12 @@ class TestProviderContentful(unittest.TestCase):
             }
         }
 
-        r_result = contentful.Client.redact_result(result)
-        r_secret = r_result['value']['secret']
+        r_result = contentful.Client.redact_result(result, {})
 
-        self.assertNotEqual(r_secret, 'THIS_IS_SECRET')
+        self.assertEqual(r_result['value']['provider'], 'splunk')
+        self.assertEqual(r_result['value']['key'], 'KEY_ID')
+        self.assertEqual(r_result['value']['secret'], '***')
+        self.assertEqual(r_result['value']['token'], '***')
 
     def test__redact_result_no_secrets(self):
         result = {
@@ -72,7 +74,7 @@ class TestProviderContentful(unittest.TestCase):
             'action': 'rotate_secret'
         }
 
-        r_result = contentful.Client.redact_result(result)
+        r_result = contentful.Client.redact_result(result, {})
 
         self.assertEqual(r_result, result)
 

--- a/tests/test_provider_qualys.py
+++ b/tests/test_provider_qualys.py
@@ -97,15 +97,16 @@ class TestProviderQualys(unittest.TestCase):
             'action': 'rotate_secret',
             'value': {
                 'provider': 'qualys',
-                'key': 'KEY_ID',
+                'username': 'SOME_USERNAME',
                 'password': 'THIS_IS_SECRET'
             }
         }
 
-        r_result = qualys.Client.redact_result(result)
-        r_value = r_result['value']['password']
+        r_result = qualys.Client.redact_result(result, {})
 
-        self.assertNotEqual(r_value, 'THIS_IS_SECRET')
+        self.assertEqual(r_result['value']['provider'], 'qualys')
+        self.assertEqual(r_result['value']['username'], 'SOME_USERNAME')
+        self.assertEqual(r_result['value']['password'], '***')
 
     def test__redact_result_no_secret(self):
         result = {
@@ -113,7 +114,7 @@ class TestProviderQualys(unittest.TestCase):
             'action': 'rotate_secret'
         }
 
-        r_result = qualys.Client.redact_result(result)
+        r_result = qualys.Client.redact_result(result, {})
 
         self.assertEqual(r_result, result)
 

--- a/tests/test_provider_salesforce.py
+++ b/tests/test_provider_salesforce.py
@@ -139,16 +139,18 @@ class TestProviderSalesforce(unittest.TestCase):
                 'provider': 'splunk',
                 'key': 'KEY_ID',
                 'secret': 'THIS_IS_SECRET',
-                'token': 'this is also secret'
+                'token': 'this is also secret',
+                'extra': 'this may as well also be secret',
             }
         }
 
         r_result = salesforce.Client.redact_result(result, SF_CREDS)
-        r_secret = r_result['value']['secret']
-        r_token = r_result['value']['token']
 
-        self.assertNotEqual(r_secret, 'THIS_IS_SECRET')
-        self.assertNotEqual(r_token, 'this is also secret')
+        self.assertEqual(r_result['value']['provider'], 'splunk')
+        self.assertEqual(r_result['value']['key'], 'KEY_ID')
+        self.assertEqual(r_result['value']['secret'], '***')
+        self.assertEqual(r_result['value']['token'], '***')
+        self.assertEqual(r_result['value']['extra'], '***')
 
     def test__redact_result_overriden_fields(self):
         result = {

--- a/tests/test_provider_salesforce_marketing_cloud.py
+++ b/tests/test_provider_salesforce_marketing_cloud.py
@@ -178,12 +178,14 @@ class TestProviderSalesforce(unittest.TestCase):
             }
         }
 
-        r_result = salesforce_marketing_cloud.Client.redact_result(result, SFMC_CREDS)
+        r_result = salesforce_marketing_cloud.Client.redact_result(result, SFMC_CFG)
 
-        self.assertNotEqual(r_result['value']['secret'], 'THIS_IS_SECRET')
-        self.assertNotEqual(r_result['value']['subdomain'], 'this is also secret')
-        self.assertNotEqual(r_result['value']['mid'], 'this is also secret')
-        self.assertNotEqual(r_result['value']['businessUnit'], 'this is also secret')
+        self.assertEqual(r_result['value']['provider'], 'salesforce_marketing_cloud')
+        self.assertEqual(r_result['value']['key'], 'KEY_ID')
+        self.assertEqual(r_result['value']['secret'], '***')
+        self.assertEqual(r_result['value']['subdomain'], '***')
+        self.assertEqual(r_result['value']['mid'], '***')
+        self.assertEqual(r_result['value']['businessUnit'], '***')
 
     def test__redact_result_overriden_fields(self):
         result = {

--- a/tests/test_provider_splunk.py
+++ b/tests/test_provider_splunk.py
@@ -100,10 +100,10 @@ class TestProviderSplunk(unittest.TestCase):
             }
         }
 
-        r_result = splunk.Client.redact_result(result)
-        r_value = r_result['value']['password']
+        r_result = splunk.Client.redact_result(result, {})
 
-        self.assertNotEqual(r_value, 'THIS_IS_SECRET')
+        self.assertEqual(r_result['value']['username'], 'KEY_ID')
+        self.assertEqual(r_result['value']['password'], '***')
 
     def test__redact_result_no_secret(self):
         result = {
@@ -111,7 +111,7 @@ class TestProviderSplunk(unittest.TestCase):
             'action': 'rotate_secret'
         }
 
-        r_result = splunk.Client.redact_result(result)
+        r_result = splunk.Client.redact_result(result, {})
 
         self.assertEqual(r_result, result)
 

--- a/tests/test_provider_splunk_hec.py
+++ b/tests/test_provider_splunk_hec.py
@@ -147,14 +147,17 @@ class TestProviderSplunkHEC(unittest.TestCase):
             'value': {
                 'provider': 'splunk',
                 'key': 'KEY_ID',
+                'hecInputName': 'INPUT_NAME',
                 f'{PW_FIELD}': 'THIS_IS_SECRET'
             }
         }
 
-        r_result = splunk_hec.Client.redact_result(result)
-        r_value = r_result['value'][PW_FIELD]
+        r_result = splunk_hec.Client.redact_result(result, {})
 
-        self.assertNotEqual(r_value, 'THIS_IS_SECRET')
+        self.assertEqual(r_result['value']['provider'], 'splunk')
+        self.assertEqual(r_result['value']['key'], 'KEY_ID')
+        self.assertEqual(r_result['value']['hecInputName'], 'INPUT_NAME')
+        self.assertEqual(r_result['value'][PW_FIELD], '***')
 
     def test__redact_result_no_secret(self):
         result = {
@@ -162,7 +165,7 @@ class TestProviderSplunkHEC(unittest.TestCase):
             'action': 'rotate_secret'
         }
 
-        r_result = splunk_hec.Client.redact_result(result)
+        r_result = splunk_hec.Client.redact_result(result, {})
 
         self.assertEqual(r_result, result)
 


### PR DESCRIPTION
Currently provider implementations have the option to explicitly redact secrets by overriding the `redact_result` method when subclassing `BaseProvider`. This prevents actual password/token values to be exposed in logs.

The current approach has some disadvantages though: 

- It is prone to leak passwords, as it logs the entire secret (including newly rotated passwords) by default.
- It leads to duplicate behaviour in subclasses, as the logic to redact values is quite generic.

This PR addresses the points above by:

- Inverting the logic so that all values are redacted by default.
- Introducing a template method to simplify the implementation of new providers, resulting in the deletion of several blocks of duplicated code.

