### PR TITLE
Add Auth0 client secret rotation

### DIFF
--- a/docs/content/examples/auth0.md
+++ b/docs/content/examples/auth0.md
@@ -1,0 +1,33 @@
+---
+title: "Auth0 Client Secret Rotation"
+date: 2024-01-15T10:00:00+11:00
+draft: false
+---
+
+Example to rotate Auth0 client secrets daily, distributing the new credentials to Secrets Manager.
+
+```yaml
+auth0_client:
+  key: auth0-dev
+  description: Auth0 client secret for web application
+  custodians: auth_team
+  provider: auth0
+  rotate: nightly
+  distribute:
+    - key: auth0/auth0/auth0-management-api-creds
+      provider: secretsmanager
+      source: secret
+      envs:
+        - dev
+```
+
+The Auth0 Management API credentials stored in `auth0/auth0/auth0-management-api-creds` should contain:
+
+```json
+{
+  "clientId": "your-management-api-client-id",
+  "clientSecret": "your-management-api-client-secret",
+  "domain": "your-tenant.auth0.com",
+  "audience": "https://your-tenant.auth0.com/api/v2/"
+}
+```

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -127,6 +127,25 @@ Like `secretsmanager`, `ssmparameterstore` is _greedy_, and the `config` section
 
 Uses client `AWS SSM Parameter Store`.
 
+## Auth0
+
+_Auth0_ (declared as `auth0`): currently can only `rotate` secrets. Rotates client secrets for Auth0 applications using the Auth0 Management API.
+
+The credentials must be provided via the `credentials` field and should contain:
+
+```json
+{
+  "clientId": "management-api-client-id",
+  "clientSecret": "management-api-client-secret",
+  "domain": "your-tenant.auth0.com",
+  "audience": "https://your-tenant.auth0.com/api/v2/"
+}
+```
+
+The Management API application must have the `update:clients` permissions.
+
+Uses client `Auth0`.
+
 ## Bitbucket
 
 *Bitbucket* (declared as `bitbucket`): can `distribute` secrets

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -6,49 +6,50 @@ draft: false
 
 ## AWS AppSync
 
-_AWS Appsync_ (declared as `appsync`): currently can only `rotate` secrets. Returns rotated keys in the format:
+*AWS Appsync* (declared as `appsync`): currently can only `rotate` secrets. Returns rotated keys in the format:
 
 ```json
-{
-  "provider": "aws_appsync",
-  "key": "key",
-  "secret": "secret"
-}
+   {
+      "provider": "aws_appsync",
+      "key": "key",
+      "secret": "secret"
+   }
 ```
 
 Uses client `AWS AppSync`.
 
 ## AWS IAM
 
-_AWS IAM_ (declared as `iam`): can only `rotate` secrets (as it doesn't really
+*AWS IAM* (declared as `iam`): can only `rotate` secrets (as it doesn't really
 make sense for it to receive (via distribution) any secrets). Returns rotated
 keys in the format:
 
 ```json
-{
-  "provider": "iam",
-  "key": "<AWS ACCESS KEY ID>",
-  "secret": "<AWS ACCESS SECRET KEY>"
-}
+   {
+      "provider": "iam",
+      "key": "<AWS ACCESS KEY ID>",
+      "secret": "<AWS ACCESS SECRET KEY>"
+   }
 ```
 
 Uses client `AWS IAM`.
 
 ## AWS Kinesis Firehose
 
-_AWS Kinesis Firehose_ (declared as `firehose`): can only `distribute` secrets to Firehose destinations. It doesn't
+*AWS Kinesis Firehose* (declared as `firehose`): can only `distribute` secrets to Firehose destinations. It doesn't
 make sense for it to rotate! The distribute spec looks like this:
 
 ```yaml
-distribute:
-  - key: streamname
-    provider: firehose
-    source: secret_key
-    config:
-      dest_type: splunk | http
-      region: AWS Region
-    envs:
-      - dev
+    distribute:
+    -
+        key: streamname
+        provider: firehose
+        source: secret_key
+        config:
+            dest_type: splunk | http
+            region: AWS Region
+        envs:
+            - dev
 ```
 
 This will distribute a secret to a Firehose delivery stream destination of type `dest_type`, for a stream name of `key`.
@@ -63,47 +64,47 @@ As an example, the Firehose Splunk destination sends events to a Splunk HTTP Eve
 rotate a HEC token nightly, and save the value to a Firehose stream located in region `us-east-1`:
 
 ```yaml
-sample:
-  key: keydra_managed_sample
-  description: Example
-  custodians: my_team
-  provider: splunk_hec
-  rotate: nightly
-  config:
-    host: my.splunkhost
-    rotatewith:
-      key: keydra/splunk/admin
-      provider: secretsmanager
-  distribute:
-    - key: streamname
-      provider: firehose
-      source: hecToken
+   sample:
+      key: keydra_managed_sample
+      description: Example
+      custodians: my_team
+      provider: splunk_hec
+      rotate: nightly
       config:
-        dest_type: splunk
-        region: us-east-1
-      envs:
-        - dev
+         host: my.splunkhost
+         rotatewith:
+            key: keydra/splunk/admin
+            provider: secretsmanager
+      distribute:
+      -
+         key: streamname
+         provider: firehose
+         source: hecToken
+         config:
+            dest_type: splunk
+            region: us-east-1
+         envs:
+            - dev
 ```
 
 Uses client `AWS Kinesis Firehose`.
 
 ## AWS Secrets Manager
 
-_AWS SecretsManager_ (declared as `secretsmanager`): can `distribute` and/or `rotate` secrets.
+*AWS SecretsManager* (declared as `secretsmanager`): can `distribute` and/or `rotate` secrets.
 
-If `rotate`ing, a `config` section must be provided, with either `bypass: true` (pretend to
+If `rotate`ing, a `config` section must be provided, with either `bypass: true` (pretend to 
 rotate, but don't really - just fetch the current password from the param) or `rotate_attribute: key` (specify the key in the JSON secret which holds the actual password value to rotate).
 
 Optionally, the `config` section can specify one or more of the following to control how new passwords are generated.
-
-- length: int (32)
-- exclude_char: str ('')
-- exclude_num: bool (False)
-- exclude_punct: bool (False)
-- exclude_upper: bool (False)
-- exclude_lower: bool (False)
-- include_space: bool (False)
-- require_each_type: bool (True)
+   - length: int (32)
+   - exclude_char: str ('')
+   - exclude_num: bool (False)
+   - exclude_punct: bool (False)
+   - exclude_upper: bool (False)
+   - exclude_lower: bool (False)
+   - include_space: bool (False)
+   - require_each_type: bool (True)
 
 `secretsmanager` is _greedy_ in other words, it will take all that is provided
 by the `secret` and stick it into AWS SecretsManager. So no 1-1 mapping or
@@ -113,11 +114,11 @@ Uses client `AWS Secrets Manager`.
 
 ## AWS Systems Manager Parameter Store
 
-_AWS SSM Parameter Store_ (declared as `ssmparameterstore`): can `distribute` and/or `rotate` secrets. It
+*AWS SSM Parameter Store* (declared as `ssmparameterstore`): can `distribute` and/or `rotate` secrets. It
 exclusively uses SecureStrings to protect secrets, and currently only supports encryption using the default
 AWS Managed Key for Parameter Store.
 
-If `rotate`ing, a `config` section must be provided, with either `bypass: true` (pretend to
+If `rotate`ing, a `config` section must be provided, with either `bypass: true` (pretend to 
 rotate, but don't really - just fetch the current password from the param) or `rotate_attribute: key` (specify the key in the JSON secret which holds the actual password value to rotate)
 
 Optionally, the `config` section can specify how new passwords are generated.
@@ -126,33 +127,14 @@ Like `secretsmanager`, `ssmparameterstore` is _greedy_, and the `config` section
 
 Uses client `AWS SSM Parameter Store`.
 
-## Auth0
-
-_Auth0_ (declared as `auth0`): currently can only `rotate` secrets. Rotates client secrets for Auth0 applications using the Auth0 Management API.
-
-The credentials must be provided via the `credentials` field and should contain:
-
-```json
-{
-  "clientId": "management-api-client-id",
-  "clientSecret": "management-api-client-secret",
-  "domain": "your-tenant.auth0.com",
-  "audience": "https://your-tenant.auth0.com/api/v2/"
-}
-```
-
-The Management API application must have the `update:clients` permissions.
-
-Uses client `Auth0`.
-
 ## Bitbucket
 
-_Bitbucket_ (declared as `bitbucket`): can `distribute` secrets
+*Bitbucket* (declared as `bitbucket`): can `distribute` secrets
 to the following scopes:
 
-- `account` (account-level env variables)
-- `repository` (build-level or development-level env variables)
-- `deployment` (deployment environment env variable)
+* `account` (account-level env variables)
+* `repository` (build-level or development-level env variables)
+* `deployment` (deployment environment env variable)
 
 In the future will also
 support `rotate` keys as its own secrets should be rotated by Keydra.
@@ -165,8 +147,8 @@ Uses client `Bitbucket`.
 
 ## Cloudflare
 
-_Cloudflare_ (declared as `cloudflare`): can `rotate` secrets. Requires a
-token with the _Can create tokens_ permission in Cloudflare, registered under
+*Cloudflare* (declared as `cloudflare`): can `rotate` secrets. Requires a
+token with the  *Can create tokens* permission in Cloudflare, registered under
 `manage_tokens.secret` in SecretsManager. When invoked rotates all of the
 tokens pertaining to that account and make their `ID` and `SECRET` available,
 as per `<token_name>.key` and `<token_name>.secret`.
@@ -177,9 +159,10 @@ Uses client `Cloudflare`.
 
 Uses client `Contentful`.
 
-# Github
+Github
+======
 
-_Github_ can `distribute` secrets to the `repository` scope only. It is also a config provider. See [About Config Providers](../config_providers)), and can be used as a
+*Github* can `distribute` secrets to the `repository` scope only. It is also a config provider. See [About Config Providers](../config_providers)), and can be used as a
 source for your secret and environment specs. In your SAM template, use `KEYDRA_CFG_PROVIDER=github` to
 tell Keydra to look in Github for secrets to manage.
 
@@ -227,22 +210,22 @@ To use Github as your main Keydra source provider, set the relevant environment 
 the following in your SAM `template.yaml`:
 
 ```yaml
-Variables:
-  KEYDRA_CFG_PROVIDER: github
-  KEYDRA_CFG_CONFIG_ACCOUNTUSERNAME: myAccountName
-  KEYDRA_CFG_CONFIG_SECRETS_REPOSITORY: keydraconfiguration
-  KEYDRA_CFG_CONFIG_SECRETS_PATH: main/config/secrets.yaml
-  KEYDRA_CFG_CONFIG_SECRETS_FILETYPE: yaml
-  KEYDRA_CFG_CONFIG_ENVIRONMENTS_REPOSITORY: keydraconfiguration
-  KEYDRA_CFG_CONFIG_ENVIRONMENTS_PATH: main/config/environments.yaml
-  KEYDRA_CFG_CONFIG_ENVIRONMENTS_FILETYPE: yaml
+   Variables:
+      KEYDRA_CFG_PROVIDER: github
+      KEYDRA_CFG_CONFIG_ACCOUNTUSERNAME: myAccountName
+      KEYDRA_CFG_CONFIG_SECRETS_REPOSITORY: keydraconfiguration
+      KEYDRA_CFG_CONFIG_SECRETS_PATH: main/config/secrets.yaml
+      KEYDRA_CFG_CONFIG_SECRETS_FILETYPE: yaml
+      KEYDRA_CFG_CONFIG_ENVIRONMENTS_REPOSITORY: keydraconfiguration
+      KEYDRA_CFG_CONFIG_ENVIRONMENTS_PATH: main/config/environments.yaml
+      KEYDRA_CFG_CONFIG_ENVIRONMENTS_FILETYPE: yaml
 ```
 
 Uses client `Github`.
 
 ## Gitlab
 
-_Gitlab_ can `distribute` secrets to the `repository` scope only. It is also a config provider (see [About Config Providers](../config_providers)), and can be used as a
+*Gitlab* can `distribute` secrets to the `repository` scope only. It is also a config provider (see [About Config Providers](../config_providers)), and can be used as a
 source for your secret and environment specs. In your SAM template, use `KEYDRA_CFG_PROVIDER=gitlab` to
 tell Keydra to look in Gitlab for secrets to manage.
 
@@ -287,17 +270,17 @@ To use Gitlab as your main Keydra source provider, set the relevant environment 
 the following in your SAM `template.yaml`:
 
 ```yaml
-Variables:
-  KEYDRA_CFG_PROVIDER: gitlab
-  KEYDRA_CFG_CONFIG_SECRETS_REPOSITORY: keydraconfiguration
-  KEYDRA_CFG_CONFIG_SECRETS_REPOSITORYBRANCH: main
-  KEYDRA_CFG_CONFIG_SECRETS_PATH: config/secrets.yaml
-  KEYDRA_CFG_CONFIG_SECRETS_FILETYPE: yaml
-  KEYDRA_CFG_CONFIG_ENVIRONMENTS_REPOSITORY: keydraconfiguration
-  KEYDRA_CFG_CONFIG_ENVIRONMENTS_REPOSITORYBRANCH: main
-  KEYDRA_CFG_CONFIG_ENVIRONMENTS_PATH: config/environments.yaml
-  KEYDRA_CFG_CONFIG_ENVIRONMENTS_FILETYPE: yaml
-  KEYDRA_CFG_CONFIG_ACCOUNTUSERNAME: notRequired
+   Variables:
+      KEYDRA_CFG_PROVIDER: gitlab
+      KEYDRA_CFG_CONFIG_SECRETS_REPOSITORY: keydraconfiguration
+      KEYDRA_CFG_CONFIG_SECRETS_REPOSITORYBRANCH: main
+      KEYDRA_CFG_CONFIG_SECRETS_PATH: config/secrets.yaml
+      KEYDRA_CFG_CONFIG_SECRETS_FILETYPE: yaml
+      KEYDRA_CFG_CONFIG_ENVIRONMENTS_REPOSITORY: keydraconfiguration
+      KEYDRA_CFG_CONFIG_ENVIRONMENTS_REPOSITORYBRANCH: main
+      KEYDRA_CFG_CONFIG_ENVIRONMENTS_PATH: config/environments.yaml
+      KEYDRA_CFG_CONFIG_ENVIRONMENTS_FILETYPE: yaml
+      KEYDRA_CFG_CONFIG_ACCOUNTUSERNAME: notRequired
 ```
 
 Uses client `Gitlab`.
@@ -315,31 +298,32 @@ secret spec needs to specify a second account to be used to make the change.
 For example, for a secret spec of:
 
 ```yaml
-sample:
-  description: API User
-  key: api
-  provider: qualys
-  rotate: nightly
-  config:
-    rotatewith:
-      key: keydra/qualys/backup
-      provider: secretsmanager
-  distribute:
-    - key: keydra/qualys/api
-      provider: secretsmanager
-      source: secret
-      envs:
-        - prod
+    sample:
+      description: API User
+      key: api
+      provider: qualys
+      rotate: nightly
+      config:
+         rotatewith:
+            key: keydra/qualys/backup
+            provider: secretsmanager
+      distribute:
+      -
+         key: keydra/qualys/api
+         provider: secretsmanager
+         source: secret
+         envs:
+            - prod
 ```
 
 The provider will take an AWS Secrets Manager secret, located at `keydra/qualys/api`:
 
 ```json
-{
-  "platform": "US3",
-  "username": "apiuser",
-  "password": "Ssh.Secret!"
-}
+   {
+      "platform": "US3",
+      "username": "apiuser",
+      "password": "Ssh.Secret!"
+   }
 ```
 
 Then use the creds of the secret at `keydra/qualys/backup` (in Secrets Manager, as configured in the spec) to
@@ -352,111 +336,113 @@ Uses client `Qualys`.
 
 ## Salesforce
 
-_Salesforce_ (declared as `salesforce`): currently can only `rotate` secrets.
+*Salesforce* (declared as `salesforce`): currently can only `rotate` secrets.
 Please note that users need to be manually created in salesforce
 before added here.
 
 Sample secret spec:
 
 ```yaml
-key: salesforce_sample
-description: Salesforce Example
-custodians: your_team
-provider: salesforce
-rotate: nightly
-distribute:
-  - key: keydra/salesforce/salesforce_sample
-    provider: secretsmanager
-    source: secret
-    envs:
-      - prod
+   key: salesforce_sample
+   description: Salesforce Example
+   custodians: your_team
+   provider: salesforce
+   rotate: nightly
+   distribute:
+   -
+      key: keydra/salesforce/salesforce_sample
+      provider: secretsmanager
+      source: secret
+      envs:
+         - prod
 ```
 
 The Secrets Manager entry format is as follows:
 
 ```yaml
-{
-  "provider": "salesforce",
-  "key": "my_sf_user",
-  "secret": "my_sf_password",
-  "token": "sf_token",
-  "domain": "sf_domain",
-}
+   {
+   "provider": "salesforce",
+   "key": "my_sf_user",
+   "secret": "my_sf_password",
+   "token": "sf_token",
+   "domain": "sf_domain"
+   }
 ```
 
 The field names can be customised via a `config` section in the spec, e.g.:
 
 ```yaml
-key: salesforce_sample
-description: Salesforce Example
-provider: salesforce
-config:
-  user_field: SF_USERNAME
-  password_field: SF_PASSWORD
-  token_field: SF_TOKEN
-  domain_field: SF_DOMAIN
-# ...
+   key: salesforce_sample
+   description: Salesforce Example
+   provider: salesforce
+   config:
+      user_field: SF_USERNAME
+      password_field: SF_PASSWORD
+      token_field: SF_TOKEN
+      domain_field: SF_DOMAIN
+   # ...
 ```
 
 Uses client `Salesforce`.
 
 ## Salesforce Marketing Cloud
 
-_Salesforce Marketing Cloud_ (declared as `salesforce_marketing_cloud`): currently can only `rotate` secrets.
+*Salesforce Marketing Cloud* (declared as `salesforce_marketing_cloud`): currently can only `rotate` secrets.
 Please note that users need to be manually created in salesforce
 before added here, and be setup with the following roles:
-
-- Administration
-  - Users - Update (Allow)
-- Email
-  - Admin
-    - API Access
-      - WebService API (Allow)
-      - XML API (Allow)
+* Administration
+   * Users - Update (Allow)
+* Email
+   * Admin
+      * API Access
+         * WebService API (Allow)
+         * XML API (Allow)
 
 Sample secret spec:
 
 ```yaml
-salesforce_marketing_cloud_user:
-  key: sfuser-dev
-  description: Secret for break glass access to Salesforce Dev
-  custodians: sf_team
-  provider: salesforce_marketing_cloud
-  rotate: nightly
-  distribute:
-    - key: keydra/salesforce/sfmc-user
-      provider: secretsmanager
-      source: secret
-      envs:
-        - dev
+    salesforce_marketing_cloud_user:
+        key: sfuser-dev
+        description: Secret for break glass access to Salesforce Dev
+        custodians: sf_team
+        provider: salesforce_marketing_cloud
+        rotate: nightly
+        distribute:
+        -
+            key: keydra/salesforce/sfmc-user
+            provider: secretsmanager
+            source: secret
+            envs:
+                - dev
 ```
 
 The Secrets Manager entry format is as follows:
 
 ```yaml
-{
-  "provider": "salesforce_marketing_cloud",
-  "SF_USERNAME": "my_sf_user",
-  "SF_PASSWORD": "my_sf_password",
-  "mid": "sfmc_instance_mid",
-  "businessUnit": "sfmc_instance_bu_id",
-  "subdomain": "sfmc_subdomain",
-}
+   {
+   "provider": "salesforce_marketing_cloud",
+   "SF_USERNAME": "my_sf_user",
+   "SF_PASSWORD": "my_sf_password",
+   "mid": "sfmc_instance_mid",
+   "businessUnit": "sfmc_instance_bu_id",
+   "subdomain": "sfmc_subdomain",
+   }
 ```
 
 The field names can be customised via a `config` section in the spec, e.g.:
 
 ```yaml
-key: salesforce_marketing_cloud sample
-description: Salesforce Marketing Cloud Example
-provider: salesforce_marketing_cloud
-config:
-  user_field: SF_USERNAME,
-  password_field: SF_PASSWORD,
-  subdomain_field: SF_SUBDOMAIN,
-  businessUnit_field: SF_BUSINESUNIT,
-  mid_field: SF_MID
-# ...
+   key: salesforce_marketing_cloud sample
+   description: Salesforce Marketing Cloud Example
+   provider: salesforce_marketing_cloud
+   config:
+      user_field: SF_USERNAME,
+      password_field: SF_PASSWORD,
+      subdomain_field: SF_SUBDOMAIN,
+      businessUnit_field: SF_BUSINESUNIT,
+      mid_field: SF_MID
+      
+   # ...
 ```
 
 Uses client `Salesforce Marketing Cloud`.
@@ -478,28 +464,29 @@ is required - the provider auto detects the type of "password" being rotated, an
 An example secret spec to rotate a Splunk user password and store in AWS Secrets Manager:
 
 ```yaml
-key: splunkuser
-description: Splunk Rotation Example
-custodians: your_team
-provider: splunk
-rotate: nightly
-config:
-  host: your.splunkhostname.com
-distribute:
-  - key: keydra/splunk/splunkuser
-    provider: secretsmanager
-    source: secret
-    envs:
-      - prod
+   key: splunkuser
+   description: Splunk Rotation Example
+   custodians: your_team
+   provider: splunk
+   rotate: nightly
+   config:
+      host: your.splunkhostname.com
+   distribute:
+   -
+      key: keydra/splunk/splunkuser
+      provider: secretsmanager
+      source: secret
+      envs:
+         - prod
 ```
 
 The Secrets Manager entry format is as follows:
 
 ```json
-{
-  "username": "splunkuser",
-  "password": "abcdefghijklmnopqrstuvwxyz1234567890"
-}
+   {
+   "username": "splunkuser",
+   "password": "abcdefghijklmnopqrstuvwxyz1234567890"
+   }
 ```
 
 Distribution is a little more complex; configuring a Splunk App or Add-On with a service account to be
@@ -513,7 +500,7 @@ The destination app must already be installed on the Splunk instance, though the
 will be created if it doesn’t already exist.
 
 | Key                 | Type   | Value                                                                                                                                                                                                                            |
-| ------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | key                 | String | The object to distribute to. Ignored/optional if we're saving to a Splunk storage password.                                                                                                                                      |
 | provider            | String | Always “splunk” for this provider.                                                                                                                                                                                               |
 | provider_secret_key | String | The credentials that should be used to authenticate to the Splunk API. In the code, this value will be prepended with `keydra/splunk/` to form the secret name in AWS Secrets Manager where the creds are stored.                |
@@ -524,7 +511,7 @@ will be created if it doesn’t already exist.
 In the `config` section:
 
 | Key       | Type   | Value                                                                                                                                                              |
-| --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|-----------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | host      | String | The Splunk host to configure. Only one destination host can be specified, if you need to distribute to more Splunk hosts you will need another distribution entry. |
 | app       | String | Splunk App context to deploy to.                                                                                                                                   |
 | appconfig | Dict   | Used to add any values needed by this Add-On. All appconfig KV pairs will be passed to the Splunk call as is.                                                      |
@@ -534,27 +521,28 @@ In the `config` section:
 An example, to rotate an IAM user and distribute it into the AWS app/TA of a Splunk instance:
 
 ```yaml
-key: km_managed_splunk
-description: Rotate an AWS Splunk integration account
-custodians: your_team
-provider: IAM
-rotate: nightly
-distribute:
-  - key: aws_security
-    provider: splunk
-    provider_secret_key: provisioning_user
-    source:
-      key_id: key
-      secret_key: secret
-    config:
-      app: Splunk_TA_aws
-      appconfig:
-        category: 1
-        output_mode: json
-      host: your.splunkhostname.com
-      path: splunk_ta_aws_aws_account
-    envs:
-      - prod
+   key: km_managed_splunk
+   description: Rotate an AWS Splunk integration account
+   custodians: your_team
+   provider: IAM
+   rotate: nightly
+   distribute:
+   -
+      key: aws_security
+      provider: splunk
+      provider_secret_key: provisioning_user
+      source:
+         key_id: key
+         secret_key: secret
+      config:
+         app: Splunk_TA_aws
+         appconfig:
+           category: 1
+           output_mode: json
+         host: your.splunkhostname.com
+         path: splunk_ta_aws_aws_account
+      envs:
+         - prod
 ```
 
 What does this do? Keydra will rotate these IAM credentials, then use the Splunk credentials stored in an AWS Secrets
@@ -598,31 +586,32 @@ An additional note on Splunk Cloud, which uses a DMC to distribute content to th
 5 minutes due to the cluster synchoronisation requirements.
 
 ```yaml
-key: hec1
-description: Splunk HEC Rotation Example
-custodians: your_team
-provider: splunk_hec
-rotate: nightly
-config:
-  host: your.splunkhostname.com
-  rotatewith:
-    key: keydra/splunk/admin
-    provider: secretsmanager
-distribute:
-  - key: keydra/splunk/hec1
-    provider: secretsmanager
-    source: secret
-    envs:
-      - prod
+   key: hec1
+   description: Splunk HEC Rotation Example
+   custodians: your_team
+   provider: splunk_hec
+   rotate: nightly
+   config:
+      host: your.splunkhostname.com
+      rotatewith:
+         key: keydra/splunk/admin
+         provider: secretsmanager
+   distribute:
+   -
+      key: keydra/splunk/hec1
+      provider: secretsmanager
+      source: secret
+      envs:
+         - prod
 ```
 
 The Secrets Manager entry format is as follows:
 
 ```json
-{
-  "hecInputName": "HEC Input Name",
-  "hecToken": "13e58a8a-ab69-4c89-8941-51b26d797e5a"
-}
+   {
+   "hecInputName": "HEC Input Name",
+   "hecToken": "13e58a8a-ab69-4c89-8941-51b26d797e5a"
+   }
 ```
 
 Uses client `Splunk`.

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -6,50 +6,49 @@ draft: false
 
 ## AWS AppSync
 
-*AWS Appsync* (declared as `appsync`): currently can only `rotate` secrets. Returns rotated keys in the format:
+_AWS Appsync_ (declared as `appsync`): currently can only `rotate` secrets. Returns rotated keys in the format:
 
 ```json
-   {
-      "provider": "aws_appsync",
-      "key": "key",
-      "secret": "secret"
-   }
+{
+  "provider": "aws_appsync",
+  "key": "key",
+  "secret": "secret"
+}
 ```
 
 Uses client `AWS AppSync`.
 
 ## AWS IAM
 
-*AWS IAM* (declared as `iam`): can only `rotate` secrets (as it doesn't really
+_AWS IAM_ (declared as `iam`): can only `rotate` secrets (as it doesn't really
 make sense for it to receive (via distribution) any secrets). Returns rotated
 keys in the format:
 
 ```json
-   {
-      "provider": "iam",
-      "key": "<AWS ACCESS KEY ID>",
-      "secret": "<AWS ACCESS SECRET KEY>"
-   }
+{
+  "provider": "iam",
+  "key": "<AWS ACCESS KEY ID>",
+  "secret": "<AWS ACCESS SECRET KEY>"
+}
 ```
 
 Uses client `AWS IAM`.
 
 ## AWS Kinesis Firehose
 
-*AWS Kinesis Firehose* (declared as `firehose`): can only `distribute` secrets to Firehose destinations. It doesn't
+_AWS Kinesis Firehose_ (declared as `firehose`): can only `distribute` secrets to Firehose destinations. It doesn't
 make sense for it to rotate! The distribute spec looks like this:
 
 ```yaml
-    distribute:
-    -
-        key: streamname
-        provider: firehose
-        source: secret_key
-        config:
-            dest_type: splunk | http
-            region: AWS Region
-        envs:
-            - dev
+distribute:
+  - key: streamname
+    provider: firehose
+    source: secret_key
+    config:
+      dest_type: splunk | http
+      region: AWS Region
+    envs:
+      - dev
 ```
 
 This will distribute a secret to a Firehose delivery stream destination of type `dest_type`, for a stream name of `key`.
@@ -64,47 +63,47 @@ As an example, the Firehose Splunk destination sends events to a Splunk HTTP Eve
 rotate a HEC token nightly, and save the value to a Firehose stream located in region `us-east-1`:
 
 ```yaml
-   sample:
-      key: keydra_managed_sample
-      description: Example
-      custodians: my_team
-      provider: splunk_hec
-      rotate: nightly
+sample:
+  key: keydra_managed_sample
+  description: Example
+  custodians: my_team
+  provider: splunk_hec
+  rotate: nightly
+  config:
+    host: my.splunkhost
+    rotatewith:
+      key: keydra/splunk/admin
+      provider: secretsmanager
+  distribute:
+    - key: streamname
+      provider: firehose
+      source: hecToken
       config:
-         host: my.splunkhost
-         rotatewith:
-            key: keydra/splunk/admin
-            provider: secretsmanager
-      distribute:
-      -
-         key: streamname
-         provider: firehose
-         source: hecToken
-         config:
-            dest_type: splunk
-            region: us-east-1
-         envs:
-            - dev
+        dest_type: splunk
+        region: us-east-1
+      envs:
+        - dev
 ```
 
 Uses client `AWS Kinesis Firehose`.
 
 ## AWS Secrets Manager
 
-*AWS SecretsManager* (declared as `secretsmanager`): can `distribute` and/or `rotate` secrets.
+_AWS SecretsManager_ (declared as `secretsmanager`): can `distribute` and/or `rotate` secrets.
 
-If `rotate`ing, a `config` section must be provided, with either `bypass: true` (pretend to 
+If `rotate`ing, a `config` section must be provided, with either `bypass: true` (pretend to
 rotate, but don't really - just fetch the current password from the param) or `rotate_attribute: key` (specify the key in the JSON secret which holds the actual password value to rotate).
 
 Optionally, the `config` section can specify one or more of the following to control how new passwords are generated.
-   - length: int (32)
-   - exclude_char: str ('')
-   - exclude_num: bool (False)
-   - exclude_punct: bool (False)
-   - exclude_upper: bool (False)
-   - exclude_lower: bool (False)
-   - include_space: bool (False)
-   - require_each_type: bool (True)
+
+- length: int (32)
+- exclude_char: str ('')
+- exclude_num: bool (False)
+- exclude_punct: bool (False)
+- exclude_upper: bool (False)
+- exclude_lower: bool (False)
+- include_space: bool (False)
+- require_each_type: bool (True)
 
 `secretsmanager` is _greedy_ in other words, it will take all that is provided
 by the `secret` and stick it into AWS SecretsManager. So no 1-1 mapping or
@@ -114,11 +113,11 @@ Uses client `AWS Secrets Manager`.
 
 ## AWS Systems Manager Parameter Store
 
-*AWS SSM Parameter Store* (declared as `ssmparameterstore`): can `distribute` and/or `rotate` secrets. It
+_AWS SSM Parameter Store_ (declared as `ssmparameterstore`): can `distribute` and/or `rotate` secrets. It
 exclusively uses SecureStrings to protect secrets, and currently only supports encryption using the default
 AWS Managed Key for Parameter Store.
 
-If `rotate`ing, a `config` section must be provided, with either `bypass: true` (pretend to 
+If `rotate`ing, a `config` section must be provided, with either `bypass: true` (pretend to
 rotate, but don't really - just fetch the current password from the param) or `rotate_attribute: key` (specify the key in the JSON secret which holds the actual password value to rotate)
 
 Optionally, the `config` section can specify how new passwords are generated.
@@ -127,14 +126,33 @@ Like `secretsmanager`, `ssmparameterstore` is _greedy_, and the `config` section
 
 Uses client `AWS SSM Parameter Store`.
 
+## Auth0
+
+_Auth0_ (declared as `auth0`): currently can only `rotate` secrets. Rotates client secrets for Auth0 applications using the Auth0 Management API.
+
+The credentials must be provided via the `credentials` field and should contain:
+
+```json
+{
+  "clientId": "management-api-client-id",
+  "clientSecret": "management-api-client-secret",
+  "domain": "your-tenant.auth0.com",
+  "audience": "https://your-tenant.auth0.com/api/v2/"
+}
+```
+
+The Management API application must have the `update:clients` permissions.
+
+Uses client `Auth0`.
+
 ## Bitbucket
 
-*Bitbucket* (declared as `bitbucket`): can `distribute` secrets
+_Bitbucket_ (declared as `bitbucket`): can `distribute` secrets
 to the following scopes:
 
-* `account` (account-level env variables)
-* `repository` (build-level or development-level env variables)
-* `deployment` (deployment environment env variable)
+- `account` (account-level env variables)
+- `repository` (build-level or development-level env variables)
+- `deployment` (deployment environment env variable)
 
 In the future will also
 support `rotate` keys as its own secrets should be rotated by Keydra.
@@ -147,8 +165,8 @@ Uses client `Bitbucket`.
 
 ## Cloudflare
 
-*Cloudflare* (declared as `cloudflare`): can `rotate` secrets. Requires a
-token with the  *Can create tokens* permission in Cloudflare, registered under
+_Cloudflare_ (declared as `cloudflare`): can `rotate` secrets. Requires a
+token with the _Can create tokens_ permission in Cloudflare, registered under
 `manage_tokens.secret` in SecretsManager. When invoked rotates all of the
 tokens pertaining to that account and make their `ID` and `SECRET` available,
 as per `<token_name>.key` and `<token_name>.secret`.
@@ -159,10 +177,9 @@ Uses client `Cloudflare`.
 
 Uses client `Contentful`.
 
-Github
-======
+# Github
 
-*Github* can `distribute` secrets to the `repository` scope only. It is also a config provider. See [About Config Providers](../config_providers)), and can be used as a
+_Github_ can `distribute` secrets to the `repository` scope only. It is also a config provider. See [About Config Providers](../config_providers)), and can be used as a
 source for your secret and environment specs. In your SAM template, use `KEYDRA_CFG_PROVIDER=github` to
 tell Keydra to look in Github for secrets to manage.
 
@@ -210,22 +227,22 @@ To use Github as your main Keydra source provider, set the relevant environment 
 the following in your SAM `template.yaml`:
 
 ```yaml
-   Variables:
-      KEYDRA_CFG_PROVIDER: github
-      KEYDRA_CFG_CONFIG_ACCOUNTUSERNAME: myAccountName
-      KEYDRA_CFG_CONFIG_SECRETS_REPOSITORY: keydraconfiguration
-      KEYDRA_CFG_CONFIG_SECRETS_PATH: main/config/secrets.yaml
-      KEYDRA_CFG_CONFIG_SECRETS_FILETYPE: yaml
-      KEYDRA_CFG_CONFIG_ENVIRONMENTS_REPOSITORY: keydraconfiguration
-      KEYDRA_CFG_CONFIG_ENVIRONMENTS_PATH: main/config/environments.yaml
-      KEYDRA_CFG_CONFIG_ENVIRONMENTS_FILETYPE: yaml
+Variables:
+  KEYDRA_CFG_PROVIDER: github
+  KEYDRA_CFG_CONFIG_ACCOUNTUSERNAME: myAccountName
+  KEYDRA_CFG_CONFIG_SECRETS_REPOSITORY: keydraconfiguration
+  KEYDRA_CFG_CONFIG_SECRETS_PATH: main/config/secrets.yaml
+  KEYDRA_CFG_CONFIG_SECRETS_FILETYPE: yaml
+  KEYDRA_CFG_CONFIG_ENVIRONMENTS_REPOSITORY: keydraconfiguration
+  KEYDRA_CFG_CONFIG_ENVIRONMENTS_PATH: main/config/environments.yaml
+  KEYDRA_CFG_CONFIG_ENVIRONMENTS_FILETYPE: yaml
 ```
 
 Uses client `Github`.
 
 ## Gitlab
 
-*Gitlab* can `distribute` secrets to the `repository` scope only. It is also a config provider (see [About Config Providers](../config_providers)), and can be used as a
+_Gitlab_ can `distribute` secrets to the `repository` scope only. It is also a config provider (see [About Config Providers](../config_providers)), and can be used as a
 source for your secret and environment specs. In your SAM template, use `KEYDRA_CFG_PROVIDER=gitlab` to
 tell Keydra to look in Gitlab for secrets to manage.
 
@@ -270,17 +287,17 @@ To use Gitlab as your main Keydra source provider, set the relevant environment 
 the following in your SAM `template.yaml`:
 
 ```yaml
-   Variables:
-      KEYDRA_CFG_PROVIDER: gitlab
-      KEYDRA_CFG_CONFIG_SECRETS_REPOSITORY: keydraconfiguration
-      KEYDRA_CFG_CONFIG_SECRETS_REPOSITORYBRANCH: main
-      KEYDRA_CFG_CONFIG_SECRETS_PATH: config/secrets.yaml
-      KEYDRA_CFG_CONFIG_SECRETS_FILETYPE: yaml
-      KEYDRA_CFG_CONFIG_ENVIRONMENTS_REPOSITORY: keydraconfiguration
-      KEYDRA_CFG_CONFIG_ENVIRONMENTS_REPOSITORYBRANCH: main
-      KEYDRA_CFG_CONFIG_ENVIRONMENTS_PATH: config/environments.yaml
-      KEYDRA_CFG_CONFIG_ENVIRONMENTS_FILETYPE: yaml
-      KEYDRA_CFG_CONFIG_ACCOUNTUSERNAME: notRequired
+Variables:
+  KEYDRA_CFG_PROVIDER: gitlab
+  KEYDRA_CFG_CONFIG_SECRETS_REPOSITORY: keydraconfiguration
+  KEYDRA_CFG_CONFIG_SECRETS_REPOSITORYBRANCH: main
+  KEYDRA_CFG_CONFIG_SECRETS_PATH: config/secrets.yaml
+  KEYDRA_CFG_CONFIG_SECRETS_FILETYPE: yaml
+  KEYDRA_CFG_CONFIG_ENVIRONMENTS_REPOSITORY: keydraconfiguration
+  KEYDRA_CFG_CONFIG_ENVIRONMENTS_REPOSITORYBRANCH: main
+  KEYDRA_CFG_CONFIG_ENVIRONMENTS_PATH: config/environments.yaml
+  KEYDRA_CFG_CONFIG_ENVIRONMENTS_FILETYPE: yaml
+  KEYDRA_CFG_CONFIG_ACCOUNTUSERNAME: notRequired
 ```
 
 Uses client `Gitlab`.
@@ -298,32 +315,31 @@ secret spec needs to specify a second account to be used to make the change.
 For example, for a secret spec of:
 
 ```yaml
-    sample:
-      description: API User
-      key: api
-      provider: qualys
-      rotate: nightly
-      config:
-         rotatewith:
-            key: keydra/qualys/backup
-            provider: secretsmanager
-      distribute:
-      -
-         key: keydra/qualys/api
-         provider: secretsmanager
-         source: secret
-         envs:
-            - prod
+sample:
+  description: API User
+  key: api
+  provider: qualys
+  rotate: nightly
+  config:
+    rotatewith:
+      key: keydra/qualys/backup
+      provider: secretsmanager
+  distribute:
+    - key: keydra/qualys/api
+      provider: secretsmanager
+      source: secret
+      envs:
+        - prod
 ```
 
 The provider will take an AWS Secrets Manager secret, located at `keydra/qualys/api`:
 
 ```json
-   {
-      "platform": "US3",
-      "username": "apiuser",
-      "password": "Ssh.Secret!"
-   }
+{
+  "platform": "US3",
+  "username": "apiuser",
+  "password": "Ssh.Secret!"
+}
 ```
 
 Then use the creds of the secret at `keydra/qualys/backup` (in Secrets Manager, as configured in the spec) to
@@ -336,113 +352,111 @@ Uses client `Qualys`.
 
 ## Salesforce
 
-*Salesforce* (declared as `salesforce`): currently can only `rotate` secrets.
+_Salesforce_ (declared as `salesforce`): currently can only `rotate` secrets.
 Please note that users need to be manually created in salesforce
 before added here.
 
 Sample secret spec:
 
 ```yaml
-   key: salesforce_sample
-   description: Salesforce Example
-   custodians: your_team
-   provider: salesforce
-   rotate: nightly
-   distribute:
-   -
-      key: keydra/salesforce/salesforce_sample
-      provider: secretsmanager
-      source: secret
-      envs:
-         - prod
+key: salesforce_sample
+description: Salesforce Example
+custodians: your_team
+provider: salesforce
+rotate: nightly
+distribute:
+  - key: keydra/salesforce/salesforce_sample
+    provider: secretsmanager
+    source: secret
+    envs:
+      - prod
 ```
 
 The Secrets Manager entry format is as follows:
 
 ```yaml
-   {
-   "provider": "salesforce",
-   "key": "my_sf_user",
-   "secret": "my_sf_password",
-   "token": "sf_token",
-   "domain": "sf_domain"
-   }
+{
+  "provider": "salesforce",
+  "key": "my_sf_user",
+  "secret": "my_sf_password",
+  "token": "sf_token",
+  "domain": "sf_domain",
+}
 ```
 
 The field names can be customised via a `config` section in the spec, e.g.:
 
 ```yaml
-   key: salesforce_sample
-   description: Salesforce Example
-   provider: salesforce
-   config:
-      user_field: SF_USERNAME
-      password_field: SF_PASSWORD
-      token_field: SF_TOKEN
-      domain_field: SF_DOMAIN
-   # ...
+key: salesforce_sample
+description: Salesforce Example
+provider: salesforce
+config:
+  user_field: SF_USERNAME
+  password_field: SF_PASSWORD
+  token_field: SF_TOKEN
+  domain_field: SF_DOMAIN
+# ...
 ```
 
 Uses client `Salesforce`.
 
 ## Salesforce Marketing Cloud
 
-*Salesforce Marketing Cloud* (declared as `salesforce_marketing_cloud`): currently can only `rotate` secrets.
+_Salesforce Marketing Cloud_ (declared as `salesforce_marketing_cloud`): currently can only `rotate` secrets.
 Please note that users need to be manually created in salesforce
 before added here, and be setup with the following roles:
-* Administration
-   * Users - Update (Allow)
-* Email
-   * Admin
-      * API Access
-         * WebService API (Allow)
-         * XML API (Allow)
+
+- Administration
+  - Users - Update (Allow)
+- Email
+  - Admin
+    - API Access
+      - WebService API (Allow)
+      - XML API (Allow)
 
 Sample secret spec:
 
 ```yaml
-    salesforce_marketing_cloud_user:
-        key: sfuser-dev
-        description: Secret for break glass access to Salesforce Dev
-        custodians: sf_team
-        provider: salesforce_marketing_cloud
-        rotate: nightly
-        distribute:
-        -
-            key: keydra/salesforce/sfmc-user
-            provider: secretsmanager
-            source: secret
-            envs:
-                - dev
+salesforce_marketing_cloud_user:
+  key: sfuser-dev
+  description: Secret for break glass access to Salesforce Dev
+  custodians: sf_team
+  provider: salesforce_marketing_cloud
+  rotate: nightly
+  distribute:
+    - key: keydra/salesforce/sfmc-user
+      provider: secretsmanager
+      source: secret
+      envs:
+        - dev
 ```
 
 The Secrets Manager entry format is as follows:
 
 ```yaml
-   {
-   "provider": "salesforce_marketing_cloud",
-   "SF_USERNAME": "my_sf_user",
-   "SF_PASSWORD": "my_sf_password",
-   "mid": "sfmc_instance_mid",
-   "businessUnit": "sfmc_instance_bu_id",
-   "subdomain": "sfmc_subdomain",
-   }
+{
+  "provider": "salesforce_marketing_cloud",
+  "SF_USERNAME": "my_sf_user",
+  "SF_PASSWORD": "my_sf_password",
+  "mid": "sfmc_instance_mid",
+  "businessUnit": "sfmc_instance_bu_id",
+  "subdomain": "sfmc_subdomain",
+}
 ```
 
 The field names can be customised via a `config` section in the spec, e.g.:
 
 ```yaml
-   key: salesforce_marketing_cloud sample
-   description: Salesforce Marketing Cloud Example
-   provider: salesforce_marketing_cloud
-   config:
-      user_field: SF_USERNAME,
-      password_field: SF_PASSWORD,
-      subdomain_field: SF_SUBDOMAIN,
-      businessUnit_field: SF_BUSINESUNIT,
-      mid_field: SF_MID
-      
-   # ...
+key: salesforce_marketing_cloud sample
+description: Salesforce Marketing Cloud Example
+provider: salesforce_marketing_cloud
+config:
+  user_field: SF_USERNAME,
+  password_field: SF_PASSWORD,
+  subdomain_field: SF_SUBDOMAIN,
+  businessUnit_field: SF_BUSINESUNIT,
+  mid_field: SF_MID
+# ...
 ```
 
 Uses client `Salesforce Marketing Cloud`.
@@ -464,29 +478,28 @@ is required - the provider auto detects the type of "password" being rotated, an
 An example secret spec to rotate a Splunk user password and store in AWS Secrets Manager:
 
 ```yaml
-   key: splunkuser
-   description: Splunk Rotation Example
-   custodians: your_team
-   provider: splunk
-   rotate: nightly
-   config:
-      host: your.splunkhostname.com
-   distribute:
-   -
-      key: keydra/splunk/splunkuser
-      provider: secretsmanager
-      source: secret
-      envs:
-         - prod
+key: splunkuser
+description: Splunk Rotation Example
+custodians: your_team
+provider: splunk
+rotate: nightly
+config:
+  host: your.splunkhostname.com
+distribute:
+  - key: keydra/splunk/splunkuser
+    provider: secretsmanager
+    source: secret
+    envs:
+      - prod
 ```
 
 The Secrets Manager entry format is as follows:
 
 ```json
-   {
-   "username": "splunkuser",
-   "password": "abcdefghijklmnopqrstuvwxyz1234567890"
-   }
+{
+  "username": "splunkuser",
+  "password": "abcdefghijklmnopqrstuvwxyz1234567890"
+}
 ```
 
 Distribution is a little more complex; configuring a Splunk App or Add-On with a service account to be
@@ -500,7 +513,7 @@ The destination app must already be installed on the Splunk instance, though the
 will be created if it doesn’t already exist.
 
 | Key                 | Type   | Value                                                                                                                                                                                                                            |
-|---------------------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | key                 | String | The object to distribute to. Ignored/optional if we're saving to a Splunk storage password.                                                                                                                                      |
 | provider            | String | Always “splunk” for this provider.                                                                                                                                                                                               |
 | provider_secret_key | String | The credentials that should be used to authenticate to the Splunk API. In the code, this value will be prepended with `keydra/splunk/` to form the secret name in AWS Secrets Manager where the creds are stored.                |
@@ -511,7 +524,7 @@ will be created if it doesn’t already exist.
 In the `config` section:
 
 | Key       | Type   | Value                                                                                                                                                              |
-|-----------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | host      | String | The Splunk host to configure. Only one destination host can be specified, if you need to distribute to more Splunk hosts you will need another distribution entry. |
 | app       | String | Splunk App context to deploy to.                                                                                                                                   |
 | appconfig | Dict   | Used to add any values needed by this Add-On. All appconfig KV pairs will be passed to the Splunk call as is.                                                      |
@@ -521,28 +534,27 @@ In the `config` section:
 An example, to rotate an IAM user and distribute it into the AWS app/TA of a Splunk instance:
 
 ```yaml
-   key: km_managed_splunk
-   description: Rotate an AWS Splunk integration account
-   custodians: your_team
-   provider: IAM
-   rotate: nightly
-   distribute:
-   -
-      key: aws_security
-      provider: splunk
-      provider_secret_key: provisioning_user
-      source:
-         key_id: key
-         secret_key: secret
-      config:
-         app: Splunk_TA_aws
-         appconfig:
-           category: 1
-           output_mode: json
-         host: your.splunkhostname.com
-         path: splunk_ta_aws_aws_account
-      envs:
-         - prod
+key: km_managed_splunk
+description: Rotate an AWS Splunk integration account
+custodians: your_team
+provider: IAM
+rotate: nightly
+distribute:
+  - key: aws_security
+    provider: splunk
+    provider_secret_key: provisioning_user
+    source:
+      key_id: key
+      secret_key: secret
+    config:
+      app: Splunk_TA_aws
+      appconfig:
+        category: 1
+        output_mode: json
+      host: your.splunkhostname.com
+      path: splunk_ta_aws_aws_account
+    envs:
+      - prod
 ```
 
 What does this do? Keydra will rotate these IAM credentials, then use the Splunk credentials stored in an AWS Secrets
@@ -586,32 +598,31 @@ An additional note on Splunk Cloud, which uses a DMC to distribute content to th
 5 minutes due to the cluster synchoronisation requirements.
 
 ```yaml
-   key: hec1
-   description: Splunk HEC Rotation Example
-   custodians: your_team
-   provider: splunk_hec
-   rotate: nightly
-   config:
-      host: your.splunkhostname.com
-      rotatewith:
-         key: keydra/splunk/admin
-         provider: secretsmanager
-   distribute:
-   -
-      key: keydra/splunk/hec1
-      provider: secretsmanager
-      source: secret
-      envs:
-         - prod
+key: hec1
+description: Splunk HEC Rotation Example
+custodians: your_team
+provider: splunk_hec
+rotate: nightly
+config:
+  host: your.splunkhostname.com
+  rotatewith:
+    key: keydra/splunk/admin
+    provider: secretsmanager
+distribute:
+  - key: keydra/splunk/hec1
+    provider: secretsmanager
+    source: secret
+    envs:
+      - prod
 ```
 
 The Secrets Manager entry format is as follows:
 
 ```json
-   {
-   "hecInputName": "HEC Input Name",
-   "hecToken": "13e58a8a-ab69-4c89-8941-51b26d797e5a"
-   }
+{
+  "hecInputName": "HEC Input Name",
+  "hecToken": "13e58a8a-ab69-4c89-8941-51b26d797e5a"
+}
 ```
 
 Uses client `Splunk`.

--- a/docs/data/menu/main.yaml
+++ b/docs/data/menu/main.yaml
@@ -27,6 +27,8 @@ main:
       ref: "/examples/gitlabawsdeployment"
     - name: Batching Keydra Runs to avoid lambda timeout
       ref: "/examples/batchingruns"
+    - name: Auth0 Client Secret Rotation
+      ref: "/examples/auth0"
   - name: Developing
     ref: "/develop"
     sub:

--- a/src/keydra/clients/auth0.py
+++ b/src/keydra/clients/auth0.py
@@ -1,0 +1,16 @@
+from auth0.authentication import GetToken
+from auth0.management import Emails, Clients
+
+class Auth0Client(object):
+    def __init__(self, client_id=None, client_secret=None, domain=None, audience=None):
+        token = GetToken(domain, client_id, client_secret).client_credentials(audience)
+        
+        self._token = token['access_token']
+        self._client_id = client_id
+        self._domain = domain
+        self._audience = audience
+        
+    def post_rotate_client(self):
+        new_client_secret = Clients(self._domain, self._token).rotate_secret(self._client_id)['client_secret']
+        
+        return new_client_secret

--- a/src/keydra/providers/auth0.py
+++ b/src/keydra/providers/auth0.py
@@ -1,0 +1,34 @@
+from keydra.clients.aws.secretsmanager import SecretsManagerClient
+from keydra.clients.auth0 import Auth0Client
+from keydra.exceptions import ConfigException, DistributionException
+from keydra.providers.base import BaseProvider, exponential_backoff_retry
+
+class Client(BaseProvider):
+    def __init__(self, session=None, credentials: dict = None, region_name=None):
+        if not credentials:
+            raise ConfigException(
+                'Credentials are required for Auth0 provider')
+
+        self._orig_secret = credentials
+        
+        self.auth0_client = Auth0Client(
+            client_id=credentials.get('clientId'),
+            client_secret=credentials.get('clientSecret'),
+            domain=credentials.get('domain'),
+            audience=credentials.get('audience')
+        )
+        
+    def _rotate_client_secret(self, secret):
+        new_client_secret = self.auth0_client.post_rotate_client()
+        
+        return {
+            **self._orig_secret,
+            'clientSecret': new_client_secret,
+        }
+        
+    @exponential_backoff_retry(3)
+    def rotate(self, secret):
+        return self._rotate_client_secret(secret)
+    
+    def distribute(self, secret, destination):
+        raise DistributionException('Auth0 does not support distribution')

--- a/src/keydra/providers/auth0.py
+++ b/src/keydra/providers/auth0.py
@@ -18,7 +18,7 @@ class Client(BaseProvider):
             audience=credentials.get('audience')
         )
         
-    def _rotate_client_secret(self, secret):
+    def _rotate_client_secret(self):
         new_client_secret = self.auth0_client.post_rotate_client()
         
         return {
@@ -28,7 +28,7 @@ class Client(BaseProvider):
         
     @exponential_backoff_retry(3)
     def rotate(self, secret):
-        return self._rotate_client_secret(secret)
+        return self._rotate_client_secret()
     
     def distribute(self, secret, destination):
         raise DistributionException('Auth0 does not support distribution')

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -15,3 +15,4 @@ urllib3==1.26.18
 validators==0.20.0
 xmltodict==0.13.0
 zeep==4.1.0
+auth0-python===4.10.0

--- a/tests/test_client_auth0.py
+++ b/tests/test_client_auth0.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from keydra.clients.auth0 import Auth0Client
+
+
+class TestAuth0Client(unittest.TestCase):
+
+    @patch('keydra.clients.auth0.GetToken')
+    @patch('keydra.clients.auth0.Clients')
+    def test__init(self, mock_clients, mock_get_token):
+        mock_token_instance = MagicMock()
+        mock_token_instance.client_credentials.return_value = {'access_token': 'test_token'}
+        mock_get_token.return_value = mock_token_instance
+
+        client = Auth0Client(
+            client_id='test_client_id',
+            client_secret='test_client_secret',
+            domain='test_domain',
+            audience='test_audience'
+        )
+
+        self.assertEqual(client._token, 'test_token')
+        self.assertEqual(client._client_id, 'test_client_id')
+        self.assertEqual(client._domain, 'test_domain')
+        self.assertEqual(client._audience, 'test_audience')
+
+        mock_get_token.assert_called_once_with('test_domain', 'test_client_id', 'test_client_secret')
+        mock_token_instance.client_credentials.assert_called_once_with('test_audience')
+
+    @patch('keydra.clients.auth0.GetToken')
+    @patch('keydra.clients.auth0.Clients')
+    def test__post_rotate_client(self, mock_clients_class, mock_get_token):
+        mock_token_instance = MagicMock()
+        mock_token_instance.client_credentials.return_value = {'access_token': 'test_token'}
+        mock_get_token.return_value = mock_token_instance
+
+        mock_clients_instance = MagicMock()
+        mock_clients_instance.rotate_secret.return_value = {'client_secret': 'new_secret'}
+        mock_clients_class.return_value = mock_clients_instance
+
+        client = Auth0Client(
+            client_id='test_client_id',
+            client_secret='test_client_secret',
+            domain='test_domain',
+            audience='test_audience'
+        )
+
+        new_secret = client.post_rotate_client()
+
+        self.assertEqual(new_secret, 'new_secret')
+        mock_clients_class.assert_called_with('test_domain', 'test_token')
+        mock_clients_instance.rotate_secret.assert_called_once_with('test_client_id')

--- a/tests/test_provider_auth0.py
+++ b/tests/test_provider_auth0.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, patch
 from keydra.exceptions import ConfigException, DistributionException
 from keydra.providers.auth0 import Client
 
-
 VALID_CREDENTIALS = {
     'clientId': 'test_client_id',
     'clientSecret': 'test_client_secret',
@@ -12,6 +11,7 @@ VALID_CREDENTIALS = {
     'audience': 'test_audience'
 }
 
+SECRET = VALID_CREDENTIALS
 
 class TestProviderAuth0(unittest.TestCase):
 
@@ -40,12 +40,7 @@ class TestProviderAuth0(unittest.TestCase):
         mock_auth0_client.return_value = mock_client_instance
 
         client = Client(credentials=VALID_CREDENTIALS)
-        result = client._rotate_client_secret(SECRET)
-
-        self.assertEqual(result['clientId'], 'test_client_id')
-        self.assertEqual(result['clientSecret'], 'new_secret_value')
-        self.assertEqual(result['domain'], 'test_domain')
-        self.assertEqual(result['audience'], '{})
+        result = client._rotate_client_secret()
 
         self.assertEqual(result['clientId'], 'test_client_id')
         self.assertEqual(result['clientSecret'], 'new_secret_value')

--- a/tests/test_provider_auth0.py
+++ b/tests/test_provider_auth0.py
@@ -1,0 +1,66 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from keydra.exceptions import ConfigException, DistributionException
+from keydra.providers.auth0 import Client
+
+
+VALID_CREDENTIALS = {
+    'clientId': 'test_client_id',
+    'clientSecret': 'test_client_secret',
+    'domain': 'test_domain',
+    'audience': 'test_audience'
+}
+
+
+class TestProviderAuth0(unittest.TestCase):
+
+    @patch('keydra.providers.auth0.Auth0Client')
+    def test__init_with_credentials(self, mock_auth0_client):
+        client = Client(credentials=VALID_CREDENTIALS)
+
+        self.assertEqual(client._orig_secret, VALID_CREDENTIALS)
+        mock_auth0_client.assert_called_once_with(
+            client_id='test_client_id',
+            client_secret='test_client_secret',
+            domain='test_domain',
+            audience='test_audience'
+        )
+
+    def test__init_without_credentials(self):
+        with self.assertRaises(ConfigException) as context:
+            Client()
+
+        self.assertEqual(str(context.exception), 'Credentials are required for Auth0 provider')
+
+    @patch('keydra.providers.auth0.Auth0Client')
+    def test__rotate_client_secret(self, mock_auth0_client):
+        mock_client_instance = MagicMock()
+        mock_client_instance.post_rotate_client.return_value = 'new_secret_value'
+        mock_auth0_client.return_value = mock_client_instance
+
+        client = Client(credentials=VALID_CREDENTIALS)
+        result = client._rotate_client_secret(SECRET)
+
+        self.assertEqual(result['clientId'], 'test_client_id')
+        self.assertEqual(result['clientSecret'], 'new_secret_value')
+        self.assertEqual(result['domain'], 'test_domain')
+        self.assertEqual(result['audience'], '{})
+
+        self.assertEqual(result['clientId'], 'test_client_id')
+        self.assertEqual(result['clientSecret'], 'new_secret_value')
+        self.assertEqual(result['domain'], 'test_domain')
+        self.assertEqual(result['audience'], 'test_audience')
+        mock_client_instance.post_rotate_client.assert_called_once()
+
+    @patch('keydra.providers.auth0.Auth0Client')
+    def test__rotate(self, mock_auth0_client):
+        mock_client_instance = MagicMock()
+        mock_client_instance.post_rotate_client.return_value = 'rotated_secret'
+        mock_auth0_client.return_value = mock_client_instance
+
+        client = Client(credentials=VALID_CREDENTIALS)
+        result = client.rotate({})
+
+        self.assertEqual(result['clientSecret'], 'rotated_secret')
+        mock_client_instance.post_rotate_client.assert_called_once()


### PR DESCRIPTION
This PR adds a new provider for Auth0 using the `auth0-python` package to enable automated rotation of Auth0 client secrets.

Changes:
- Added `Auth0Client` class to interact with Auth0 Management API for secret rotation
- Implemented auth0 provider with rotate functionality
- Included documentation example showing nightly rotation with Secrets Manager distribution